### PR TITLE
fix: Correct the wrong deviceClient pointer assignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-onvif-camera
 
 require (
-	github.com/IOTechSystems/onvif v0.0.2-0.20220103021116-4543eed40749
+	github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b
 	github.com/edgexfoundry/device-sdk-go/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/IOTechSystems/onvif v0.0.2-0.20220103021116-4543eed40749 h1:wmPl/zoTR1tzzVvEvAYWukVyNPamsPwv7YHsuKgyvyo=
 github.com/IOTechSystems/onvif v0.0.2-0.20220103021116-4543eed40749/go.mod h1:vMGzqucCPsrADcnQ7oYah1HYr3h4zdoNVzcPmcyKy6o=
+github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b h1:3n2UWJDN5hGI10ehQUwtDScvZXGo0WNAttMQQ7dovV8=
+github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b/go.mod h1:vMGzqucCPsrADcnQ7oYah1HYr3h4zdoNVzcPmcyKy6o=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -103,19 +103,19 @@ func (d *Driver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkModel.As
 func (d *Driver) getDeviceClient(deviceName string) (*DeviceClient, errors.EdgeX) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
-	c, ok := d.deviceClients[deviceName]
+	deviceClient, ok := d.deviceClients[deviceName]
 	if !ok {
 		device, err := sdk.RunningService().GetDeviceByName(deviceName)
 		if err != nil {
 			return nil, errors.NewCommonEdgeXWrapper(err)
 		}
-		deviceClient, err := NewDeviceClient(device, d.config, d.lc)
+		deviceClient, err = NewDeviceClient(device, d.config, d.lc)
 		if err != nil {
 			return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to initial device client for '%s' camera", device.Name), err)
 		}
 		d.deviceClients[deviceName] = deviceClient
 	}
-	return c, nil
+	return deviceClient, nil
 }
 
 func (d *Driver) removeDeviceClient(deviceName string) {


### PR DESCRIPTION
Close #5

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) **not impact the test**
- [ ] Docs have been added / updated (for bug fixes / features) **not impact the doc**

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The device service throw panic error during AutoEvent

## Issue Number: #5


## What is the new behavior?
To fix the nil pointer error, correct the wrong deviceClient pointer assignment.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information