### PR TITLE
feat: Replace the serial number with endpointReference address UUID

### DIFF
--- a/doc/auto-discovery.md
+++ b/doc/auto-discovery.md
@@ -124,7 +124,7 @@ For example:
     {
       "apiVersion": "v2",
       "device": {
-        "name":"HIKVISION-DFI6256TE-DFI6256TE20190608AAWRD26707311",
+        "name":"HIKVISION-DFI6256TE-cea94000-fb96-11b3-8260-686dbc5cb15d",
         "serviceName": "device-onvif-camera",
         "profileName": "onvif-camera",
         "description": "HIKVISION camera",
@@ -145,7 +145,7 @@ For example:
     }
     ```
 
-- Device Name:  Manufacturer-Model-SerialNumber
+- Device Name:  Manufacturer-Model-UUID (The UUID extracted from the probe response's EndpointReference address)
 - The serviceName, profileName, adminState, autoEvets are defined by the provisionWatcher
 - Predefine the driver config authMode and secretPath for discovered device, for exmaple:
   - DefaultAuthMode="usernametoken"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-onvif-camera
 
 require (
-	github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b
+	github.com/IOTechSystems/onvif v0.0.2-0.20220301065030-7cf2dd734897
 	github.com/edgexfoundry/device-sdk-go/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/IOTechSystems/onvif v0.0.2-0.20220103021116-4543eed40749 h1:wmPl/zoTR1tzzVvEvAYWukVyNPamsPwv7YHsuKgyvyo=
-github.com/IOTechSystems/onvif v0.0.2-0.20220103021116-4543eed40749/go.mod h1:vMGzqucCPsrADcnQ7oYah1HYr3h4zdoNVzcPmcyKy6o=
-github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b h1:3n2UWJDN5hGI10ehQUwtDScvZXGo0WNAttMQQ7dovV8=
-github.com/IOTechSystems/onvif v0.0.2-0.20220223143907-b50211157c1b/go.mod h1:vMGzqucCPsrADcnQ7oYah1HYr3h4zdoNVzcPmcyKy6o=
+github.com/IOTechSystems/onvif v0.0.2-0.20220301065030-7cf2dd734897 h1:2ieBV/UtmRrnw9law65MO8ZkA/dbjxke2Cgo9/NoMoY=
+github.com/IOTechSystems/onvif v0.0.2-0.20220301065030-7cf2dd734897/go.mod h1:vMGzqucCPsrADcnQ7oYah1HYr3h4zdoNVzcPmcyKy6o=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -299,6 +299,10 @@ func (d *Driver) Discover() {
 	onvifDevices := wsdiscovery.GetAvailableDevicesAtSpecificEthernetInterface(d.config.DiscoveryEthernetInterface)
 	var discoveredDevices []sdkModel.DiscoveredDevice
 	for _, onvifDevice := range onvifDevices {
+		if onvifDevice.GetDeviceParams().EndpointRefAddress == "" {
+			d.lc.Warnf("The EndpointRefAddress is empty from the Onvif camera, unable to add the camera %s", onvifDevice.GetDeviceParams().Xaddr)
+			continue
+		}
 		address, port := addressAndPort(onvifDevice.GetDeviceParams().Xaddr)
 		dev := models.Device{
 			// Using Xaddr as the temporary name
@@ -325,7 +329,7 @@ func (d *Driver) Discover() {
 		dev.Protocols[OnvifProtocol][SerialNumber] = devInfo.SerialNumber
 		dev.Protocols[OnvifProtocol][HardwareId] = devInfo.HardwareId
 		discovered := sdkModel.DiscoveredDevice{
-			Name:        fmt.Sprintf("%s-%s-%s", devInfo.Manufacturer, devInfo.Model, devInfo.SerialNumber),
+			Name:        fmt.Sprintf("%s-%s-%s", devInfo.Manufacturer, devInfo.Model, onvifDevice.GetDeviceParams().EndpointRefAddress),
 			Protocols:   dev.Protocols,
 			Description: fmt.Sprintf("%s %s Camera", devInfo.Manufacturer, devInfo.Model),
 			Labels:      []string{"auto-discovery", devInfo.Manufacturer, devInfo.Model},


### PR DESCRIPTION
Close #2

Signed-off-by: bruce <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) **not impact the teat**
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The serial number is the same for the different TAPO C200 cameras, the device name would be duplicated.

## Issue Number: #2


## What is the new behavior?
Replace the serial number with EndpointReference Address UUID as the part of the device name

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information