### PR TITLE
fix: remove spaces from device name

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -336,8 +336,15 @@ func (d *Driver) Discover() {
 			dev.Protocols[OnvifProtocol][FirmwareVersion] = devInfo.FirmwareVersion
 			dev.Protocols[OnvifProtocol][SerialNumber] = devInfo.SerialNumber
 			dev.Protocols[OnvifProtocol][HardwareId] = devInfo.HardwareId
+
+			// Spaces are not allowed in the device name
+			deviceName := fmt.Sprintf("%s-%s-%s",
+				strings.ReplaceAll(devInfo.Manufacturer, " ", "-"),
+				strings.ReplaceAll(devInfo.Model, " ", "-"),
+				onvifDevice.GetDeviceParams().EndpointRefAddress)
+
 			discovered = sdkModel.DiscoveredDevice{
-				Name:        fmt.Sprintf("%s-%s-%s", devInfo.Manufacturer, devInfo.Model, onvifDevice.GetDeviceParams().EndpointRefAddress),
+				Name:        deviceName,
 				Protocols:   dev.Protocols,
 				Description: fmt.Sprintf("%s %s Camera", devInfo.Manufacturer, devInfo.Model),
 				Labels:      []string{"auto-discovery", devInfo.Manufacturer, devInfo.Model},


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#14 

## What is the new behavior?
Spaces are replaced with hyphens in the device name

`Bosch-DINION-IP-starlight-6000-HD-00075fc4-23b6-b623-c45f-0700075fc45f`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information