### PR TITLE
updated auto-discovery-docker documentation

### DIFF
--- a/doc/auto-discovery-docker.md
+++ b/doc/auto-discovery-docker.md
@@ -20,7 +20,7 @@ Note: For macOS, the network_mode: "host" probably not working as expected: http
 ```
 services:
   device-onvif-camera:
-    image: edgex/device-onvif-camera${ARCH}:${DEVICE_ONVIFCAM_VERSION}
+    image: edgexfoundry/device-onvif-camera${ARCH}:${DEVICE_ONVIFCAM_VERSION}
     user: "${EDGEX_USER}:${EDGEX_GROUP}"
     container_name: edgex-device-onvif-camera
     hostname: edgex-device-onvif-camera
@@ -41,7 +41,7 @@ services:
       - metadata
     security_opt:
       - no-new-privileges:true
-    command: --registry --confdir=/res
+    command: -cp=consul.http://localhost:8500 --registry --confdir=/res
 ```
 
 **Note**: The user should replace the host IP to match their own machine IP


### PR DESCRIPTION
Below things needs to update in auto-discover-docker documentation:
1. Device onvif camera image path should change to edgexfoundry/
2. Command needs to have -cp=consul.http://localhost:8500 for credentials to sync with device service after user provides camera credentials. Without this, onvif device service not able to retrieve camera credentials from consul and api's are not working.