### PR TITLE
fix: override server bind address to 0.0.0.0

### DIFF
--- a/doc/auto-discovery-docker.md
+++ b/doc/auto-discovery-docker.md
@@ -29,11 +29,11 @@ services:
     network_mode: "host"
     environment:
       SERVICE_HOST: 192.168.56.101
+      SERVICE_SERVERBINDADDR: 0.0.0.0
       EDGEX_SECURITY_SECRET_STORE: "false"
       DEVICE_DISCOVERY_ENABLED: "true"
       DRIVER_DISCOVERYETHERNETINTERFACE: enp0s3
       DRIVER_DEFAULTSECRETPATH: credentials001
-      
       WRITABLE_LOGLEVEL: DEBUG
     depends_on:
       - consul
@@ -102,6 +102,7 @@ services:
     network_mode: host
     environment:
       SERVICE_HOST: 192.168.56.101
+      SERVICE_SERVERBINDADDR: 0.0.0.0
       EDGEX_SECURITY_SECRET_STORE: "true"
       DEVICE_DISCOVERY_ENABLED: "true"
       DRIVER_DISCOVERYETHERNETINTERFACE: enp0s3


### PR DESCRIPTION
- this will allow it to still be called via localhost and not just the
  external IP address

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>
