### PR TITLE
fix: Update Makefile to show the version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,17 @@ ARCH=$(shell uname -m)
 MICROSERVICES=cmd/device-onvif-camera
 .PHONY: $(MICROSERVICES)
 
+# VERSION file is not needed for local development, In the CI/CD pipeline, a temporary VERSION file is written
 VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 
+# This pulls the version of the SDK from the go.mod file
+SDKVERSION=$(shell cat ./go.mod | grep 'github.com/edgexfoundry/device-sdk-go/v2 v' | awk '{print $$2}')
+
 GIT_SHA=$(shell git rev-parse HEAD)
-GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-onvif-camera.Version=$(VERSION)"  -trimpath -mod=readonly
-CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-onvif-camera.Version=$(VERSION)" -trimpath -mod=readonly -buildmode=pie
+CGOFLAGS=-ldflags "-linkmode=external \
+                   -X github.com/edgexfoundry/device-onvif-camera.Version=$(VERSION) \
+                   -X github.com/edgexfoundry/device-sdk-go/v2/internal/common.SDKVersion=$(SDKVERSION)" \
+                   -trimpath -mod=readonly -buildmode=pie
 
 build: $(MICROSERVICES)
 


### PR DESCRIPTION
Close #67

Signed-off-by: bruce <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) **not impact the test**
- [ ] Docs have been added / updated (for bug fixes / features) **not impact the doc**

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Issue Number: #67


## What is the new behavior?
Update Makefile to show the service version and sdk version

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Local build and execute the API as below:
```
$ curl http://localhost:59984/api/v2/version
{"apiVersion":"v2","version":"0.0.0","serviceName":"device-onvif-camera","sdk_version":"v2.2.0"}
```