### PR TITLE
docs: style and reformat tested cameras matrix

### DIFF
--- a/doc/tested-onvif-camera.md
+++ b/doc/tested-onvif-camera.md
@@ -1,93 +1,110 @@
-# Tested Onvif Camera
-The following table shows the tested Onvif cameras with Onvif functions:
+# Tested Onvif Cameras
+The following table shows the Onvif functions tested for various Onvif cameras:
 
-* 'O' means the function works for the camera.
-* 'X' means the function not work for the camera. The camera might not perform the request or return empty response.
+* '✔' means the function works for the specified camera.
+* '❌' means the function does not work or is not implemented by the specified camera.
 
-| Feature                            | Onvif Web Service | Onvif Function                      | Hikvision DFI6256TE | Tapo C200 | BOSCH DINION IP starlight 6000 HD | GeoVision GV-BX8700 |
-|------------------------------------|-------------------|-------------------------------------|---------------------|-----------|-----------------------------------|---------------------|
-| User Authentication                | Core              | **WS-Usernametoken Authentication** | O                   | O         | O                                 | O                   |
-|                                    |                   | **HTTP Digest**                     | O                   | X         | O                                 | X                   |
-| Auto Discovery                     | Core              | **WS-Discovery**                    | O                   | O         | O                                 | O                   |
-|                                    | Device            | GetDiscoveryMode                    | O                   | O         | O                                 | O                   |
-|                                    |                   | SetDiscoveryMode                    | O                   | O         | O                                 | O                   |
-|                                    |                   | GetScopes                           | O                   | O         | O                                 | O                   |
-|                                    |                   | SetScopes                           | O                   | O         | O                                 | O                   |
-|                                    |                   | AddScopes                           | O                   | X         | O                                 | O                   |
-|                                    |                   | RemoveScopes                        | O                   | X         | O                                 | O                   |
-| Network Configuration              | Device            | GetHostname                         | O                   | O         | O                                 | O                   |
-|                                    |                   | SetHostname                         | O                   | X         | O                                 | O                   |
-|                                    |                   | GetDNS                              | O                   | X         | O                                 | O                   |
-|                                    |                   | SetDNS                              | O                   | X         | O                                 | O                   |
-|                                    |                   | **GetNetworkInterfaces**            | O                   | O         | O                                 | O                   |
-|                                    |                   | **SetNetworkInterfaces**            | O                   | X         | O                                 | O                   |
-|                                    |                   | GetNetworkProtocols                 | O                   | O         | O                                 | O                   |
-|                                    |                   | SetNetworkProtocols                 | O                   | X         | O                                 | O                   |
-|                                    |                   | **GetNetworkDefaultGateway**        | O                   | X         | O                                 | O                   |
-|                                    |                   | **SetNetworkDefaultGateway**        | O                   | X         | O                                 | O                   |
-| System Function                    | Device            | **GetDeviceInformation**            | O                   | O         | O                                 | O                   |
-|                                    |                   | GetSystemDateAndTime                | O                   | O         | O                                 | O                   |
-|                                    |                   | SetSystemDateAndTime                | O                   | X         | O                                 | O                   |
-|                                    |                   | SetSystemFactoryDefault             | O                   | O         | O                                 | O                   |
-|                                    |                   | Reboot                              | O                   | O         | O                                 | O                   |
-| User Handling                      | Device            | **GetUsers**                        | O                   | X         | O                                 | O                   |
-|                                    |                   | **CreateUsers**                     | O                   | X         | O                                 | O                   |
-|                                    |                   | **DeleteUsers**                     | O                   | X         | O                                 | O                   |
-|                                    |                   | **SetUser**                         | O                   | X         | O                                 | O                   |
-| Metadata Configuration             | Media             | GetMetadataConfigurations           | O                   | X         | O                                 | O                   |
-|                                    |                   | GetMetadataConfiguration            | O                   | X         | O                                 | O                   |
-|                                    |                   | GetCompatibleMetadataConfigurations | O                   | X         | O                                 | O                   |
-|                                    |                   | **GetMetadataConfigurationOptions** | O                   | X         | O                                 | O                   |
-|                                    |                   | AddMetadataConfiguration            | O                   | X         | O                                 | O                   |
-|                                    |                   | RemoveMetadataConfiguration         | O                   | X         | O                                 | O                   |
-|                                    |                   | **SetMetadataConfiguration**        | O                   | X         | O                                 | O                   |
-| Video Streaming                    | Media             | **GetProfiles**                     | O                   | O         | O                                 | O                   |
-|                                    |                   | **GetStreamUri**                    | O                   | O         | O                                 | O                   |
-|                                    | EdgeX             | **GetSnapshot**                     | O                   | X         | O                                 | X                   |
-| VideoEncoder  Config               | Media             | GetVideoEncoderConfiguration        | O                   | O         | O                                 | O                   |
-|                                    |                   | **SetVideoEncoderConfiguration**    | O                   | X         | O                                 | O                   |
-|                                    |                   | GetVideoEncoderConfigurationOptions | O                   | O         | O                                 | O                   |
-| PTZ Node                           | PTZ               | GetNodes                            | X                   | O         | X                                 | X                   |
-|                                    |                   | GetNode                             | X                   | O         | X                                 | X                   |
-| PTZ Configuration                  | PTZ               | GetConfigurations                   | X                   | O         | X                                 | X                   |
-|                                    |                   | GetConfiguration                    | X                   | O         | X                                 | X                   |
-|                                    |                   | GetConfigurationOptions             | X                   | O         | X                                 | X                   |
-|                                    |                   | SetConfiguration                    | X                   | X         | X                                 | X                   |
-|                                    | Media             | AddPTZConfiguration                 | X                   | X         | X                                 | X                   |
-|                                    | Media             | RemovePTZConfiguration              | X                   | X         | X                                 | X                   |
-| PTZ Actuation                      | PTZ               | AbsoluteMove                        | X                   | O         | X                                 | X                   |
-|                                    |                   | RelativeMove                        | X                   | O         | X                                 | X                   |
-|                                    |                   | ContinuousMove                      | X                   | O         | X                                 | X                   |
-|                                    |                   | Stop                                | X                   | O         | X                                 | X                   |
-|                                    |                   | GetStatus                           | X                   | O         | X                                 | X                   |
-| PTZ Preset                         | PTZ               | SetPreset                           | X                   | O         | X                                 | X                   |
-|                                    |                   | GetPresets                          | X                   | O         | X                                 | X                   |
-|                                    |                   | GotoPreset                          | X                   | O         | X                                 | X                   |
-|                                    |                   | RemovePreset                        | X                   | O         | X                                 | X                   |
-| PTZ Home Position                  | PTZ               | GotoHomePosition                    | X                   | X         | X                                 | X                   |
-|                                    |                   | SetHomePosition                     | X                   | X         | X                                 | X                   |
-| PTZ AuxiliaryOperations            | PTZ               | SendAuxiliaryCommand                | X                   | X         | X                                 | X                   |
-| Event Handling                     | Event             | Notify                              | O                   | X         | O                                 | X                   |
-|                                    |                   | Subscribe                           | O                   | X         | O                                 | X                   |
-|                                    |                   | Renew                               | X                   | X         | O                                 | X                   |
-|                                    |                   | Unsubscribe                         | O                   | X         | O                                 | X                   |
-|                                    |                   | CreatePullPointSubscription         | O                   | X         | O                                 | X                   |
-|                                    |                   | PullMessages                        | O                   | X         | O                                 | X                   |
-|                                    |                   | TopicFilter                         | O                   | X         | O                                 | X                   |
-|                                    |                   | MessageContentFilter                | X                   | X         | X                                 | X                   |
-| Configuration of Analytics profile | Media2            | GetProfiles                         | X                   | X         | O                                 | X                   |
-|                                    |                   | GetAnalyticsConfigurations          | X                   | X         | O                                 | X                   |
-|                                    |                   | AddConfiguration                    | X                   | X         | O                                 | X                   |
-|                                    |                   | RemoveConfiguration                 | X                   | X         | O                                 | X                   |
-| Analytics Module configuration     | Analytics         | GetSupportedAnalyticsModules        | X                   | X         | O                                 | X                   |
-|                                    |                   | GetAnalyticsModules                 | X                   | X         | O                                 | X                   |
-|                                    |                   | CreateAnalyticsModules              | X                   | X         | X                                 | X                   |
-|                                    |                   | DeleteAnalyticsModules              | X                   | X         | X                                 | X                   |
-|                                    |                   | GetAnalyticsModuleOptions           | X                   | X         | O                                 | X                   |
-|                                    |                   | ModifyAnalyticsModules              | X                   | X         | O                                 | X                   |
-| Rule configuration                 | Analytics         | GetSupportedRules                   | X                   | X         | O                                 | X                   |
-|                                    |                   | GetRules                            | X                   | X         | O                                 | X                   |
-|                                    |                   | CreateRules                         | X                   | X         | O                                 | X                   |
-|                                    |                   | DeleteRules                         | X                   | X         | O                                 | X                   |
-|                                    |                   | GetRuleOptions                      | X                   | X         | O                                 | X                   |
-|                                    |                   | ModifyRules                         | X                   | X         | O                                 | X                   |
+| Feature                                | Onvif Web Service | Onvif Function                      | Hikvision DFI6256TE | Tapo C200 | BOSCH DINION IP starlight 6000 HD | GeoVision GV-BX8700 |
+|----------------------------------------|-------------------|-------------------------------------|---------------------|-----------|-----------------------------------|---------------------|
+| **User Authentication**                | **Core**          | WS-UsernameToken                    | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | HTTP Digest                         | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **Auto Discovery**                     | **Core**          | WS-Discovery                        | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        | **Device**        | GetDiscoveryMode                    | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetDiscoveryMode                    | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | GetScopes                           | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetScopes                           | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | AddScopes                           | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | RemoveScopes                        | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **Network Configuration**              | **Device**        | GetHostname                         | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetHostname                         | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetDNS                              | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | SetDNS                              | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetNetworkInterfaces                | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetNetworkInterfaces                | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetNetworkProtocols                 | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetNetworkProtocols                 | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetNetworkDefaultGateway            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | SetNetworkDefaultGateway            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **System Function**                    | **Device**        | GetDeviceInformation                | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | GetSystemDateAndTime                | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetSystemDateAndTime                | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | SetSystemFactoryDefault             | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | Reboot                              | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **User Handling**                      | **Device**        | GetUsers                            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | CreateUsers                         | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | DeleteUsers                         | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | SetUser                             | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **Metadata Configuration**             | **Media**         | GetMetadataConfigurations           | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetMetadataConfiguration            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetCompatibleMetadataConfigurations | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetMetadataConfigurationOptions     | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | AddMetadataConfiguration            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | RemoveMetadataConfiguration         | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | SetMetadataConfiguration            | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **Video Streaming**                    | **Media**         | GetProfiles                         | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | GetStreamUri                        | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        | **EdgeX**         | GetSnapshot                         | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **VideoEncoder  Config**               | **Media**         | GetVideoEncoderConfiguration        | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   | SetVideoEncoderConfiguration        | ✔                   | ❌         | ✔                                 | ✔                   |
+|                                        |                   | GetVideoEncoderConfigurationOptions | ✔                   | ✔         | ✔                                 | ✔                   |
+|                                        |                   |                                     |                     |
+| **PTZ Node**                           | **PTZ**           | GetNodes                            | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GetNode                             | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **PTZ Configuration**                  | **PTZ**           | GetConfigurations                   | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GetConfiguration                    | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GetConfigurationOptions             | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | SetConfiguration                    | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        | **Media**         | AddPTZConfiguration                 | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        | **Media**         | RemovePTZConfiguration              | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **PTZ Actuation**                      | **PTZ**           | AbsoluteMove                        | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | RelativeMove                        | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | ContinuousMove                      | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | Stop                                | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GetStatus                           | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **PTZ Preset**                         | **PTZ**           | SetPreset                           | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GetPresets                          | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | GotoPreset                          | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   | RemovePreset                        | ❌                   | ✔         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **PTZ Home Position**                  | **PTZ**           | GotoHomePosition                    | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   | SetHomePosition                     | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **PTZ AuxiliaryOperations**            | **PTZ**           | SendAuxiliaryCommand                | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **Event Handling**                     | **Event**         | Notify                              | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | Subscribe                           | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | Renew                               | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | Unsubscribe                         | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | CreatePullPointSubscription         | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | PullMessages                        | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | TopicFilter                         | ✔                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | MessageContentFilter                | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **Configuration of Analytics profile** | **Media2**        | GetProfiles                         | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | GetAnalyticsConfigurations          | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | AddConfiguration                    | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | RemoveConfiguration                 | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   |                                     |                     | 
+| **Analytics Module configuration**     | **Analytics**     | GetSupportedAnalyticsModules        | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | GetAnalyticsModules                 | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | CreateAnalyticsModules              | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   | DeleteAnalyticsModules              | ❌                   | ❌         | ❌                                 | ❌                   |
+|                                        |                   | GetAnalyticsModuleOptions           | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | ModifyAnalyticsModules              | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   |                                     |                     |
+| **Rule configuration**                 | **Analytics**     | GetSupportedRules                   | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | GetRules                            | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | CreateRules                         | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | DeleteRules                         | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | GetRuleOptions                      | ❌                   | ❌         | ✔                                 | ❌                   |
+|                                        |                   | ModifyRules                         | ❌                   | ❌         | ✔                                 | ❌                   |


### PR DESCRIPTION
- use unicode characters instead of X/O
- add divider between features
- fix grammer
- bold sections and not commands

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>


> Note: View rendered version: https://github.com/ajcasagrande/device-onvif-camera/blob/patch-1/doc/tested-onvif-camera.md