### PR TITLE
Custom config structs, auto provision watcher, debounced discovery

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -103,11 +103,11 @@ UseMessageBus = true
   Enabled = true
   Interval = "1h"
 
-# Driver configs
-[Driver]
-CredentialsRetryTime = "120" # Seconds
-CredentialsRetryWait = "1" # Seconds
-RequestTimeout = "5" # Seconds
+# Custom configs
+[AppCustom]
+CredentialsRetryTime = 120 # Seconds
+CredentialsRetryWait = 1 # Seconds
+RequestTimeout = 5 # Seconds
 DiscoveryEthernetInterface = ""
 DefaultAuthMode = "usernametoken"
 DefaultSecretPath = "credentials001"
@@ -122,12 +122,12 @@ DiscoveryMode = "both" # netscan, multicast, or both
 DiscoverySubnets = ""
 
 # Maximum simultaneous network probes
-ProbeAsyncLimit = "4000"
+ProbeAsyncLimit = 4000
 
 # Maximum amount of milliseconds to wait for each IP probe before timing out.
 # This will also be the minimum time the discovery process can take.
-ProbeTimeoutMillis = "2000"
+ProbeTimeoutMillis = 2000
 
 # Maximum amount of seconds the discovery process is allowed to run before it will be cancelled.
 # It is especially important to have this configured in the case of larger subnets such as /16 and /8
-MaxDiscoverDurationSeconds = "300"
+MaxDiscoverDurationSeconds = 300

--- a/cmd/res/provision_watchers/generic.provision.watcher.json
+++ b/cmd/res/provision_watchers/generic.provision.watcher.json
@@ -1,0 +1,11 @@
+{
+    "name":"Generic-Onvif-Provision-Watcher",
+    "identifiers":{
+        "Address": "."
+    },
+    "blockingIdentifiers":{
+    },
+    "serviceName": "device-onvif-camera",
+    "profileName": "onvif-camera",
+    "adminState":"UNLOCKED"
+}

--- a/internal/driver/basenotificationconsumer.go
+++ b/internal/driver/basenotificationconsumer.go
@@ -144,8 +144,12 @@ func (consumer *Consumer) subscribeRequest() *event.Subscribe {
 	InitialTerminationTime := xsd.String(*consumer.subscriptionRequest.InitialTerminationTime)
 	subscriptionPolicy := xsd.String(*consumer.subscriptionRequest.SubscriptionPolicy)
 
+	consumer.onvifClient.driver.configMu.RLock()
+	baseNotificationURL := consumer.onvifClient.driver.config.AppCustom.BaseNotificationURL
+	consumer.onvifClient.driver.configMu.RUnlock()
+
 	address := fmt.Sprintf("%s%s/%s/%s/%s",
-		consumer.onvifClient.driverConfig.BaseNotificationURL, common.ApiBase, OnvifEventRestPath, consumer.onvifClient.DeviceName, consumer.onvifClient.CameraEventResource.Name)
+		baseNotificationURL, common.ApiBase, OnvifEventRestPath, consumer.onvifClient.DeviceName, consumer.onvifClient.CameraEventResource.Name)
 	consumerReference := &event.EndpointReferenceType{
 		Address: event.AttributedURIType(address),
 	}

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -15,7 +15,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
-type configuration struct {
+// CustomConfig holds the values for the driver configuration
+type CustomConfig struct {
 	CredentialsRetryTime int
 	CredentialsRetryWait int
 	RequestTimeout       int
@@ -38,6 +39,27 @@ type configuration struct {
 	ProbeTimeoutMillis int
 	// MaxDiscoverDurationSeconds indicates the amount of seconds discovery will run before timing out.
 	MaxDiscoverDurationSeconds int
+
+	// Location of Provision Watchers
+	ProvisionWatcherDir string
+}
+
+// ServiceConfig a struct that wraps CustomConfig which holds the values for driver configuration
+type ServiceConfig struct {
+	AppCustom CustomConfig
+}
+
+// UpdateFromRaw updates the service's full configuration from raw data received from
+// the Service Provider.
+func (c *ServiceConfig) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ServiceConfig)
+	if !ok {
+		return false
+	}
+
+	*c = *configuration
+
+	return true
 }
 
 // CameraInfo holds the camera connection info
@@ -46,16 +68,6 @@ type CameraInfo struct {
 	Port       int
 	AuthMode   string
 	SecretPath string
-}
-
-// loadCameraConfig loads the camera configuration
-func loadCameraConfig(configMap map[string]string) (*configuration, error) {
-	config := new(configuration)
-	err := load(configMap, config)
-	if err != nil {
-		return config, err
-	}
-	return config, nil
 }
 
 // CreateCameraInfo creates new CameraInfo entity from the protocol properties

--- a/internal/driver/config_test.go
+++ b/internal/driver/config_test.go
@@ -1,0 +1,56 @@
+package driver
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUpdateFromRaw(t *testing.T) {
+	expectedConfig := &ServiceConfig{
+		AppCustom: CustomConfig{
+			CredentialsRetryTime:       5,
+			CredentialsRetryWait:       5,
+			RequestTimeout:             5,
+			DefaultAuthMode:            "usernametoken",
+			DefaultSecretPath:          "default_secret",
+			DiscoveryEthernetInterface: "eth0",
+			BaseNotificationURL:        "http://localhost:59984",
+			DiscoveryMode:              "netscan",
+			DiscoverySubnets:           "127.0.0.1/32,127.0.1.1/32",
+			ProbeAsyncLimit:            50,
+			ProbeTimeoutMillis:         1000,
+			MaxDiscoverDurationSeconds: 5,
+			ProvisionWatcherDir:        "res/provision_watchers",
+		},
+	}
+	testCases := []struct {
+		Name      string
+		rawConfig interface{}
+		isValid   bool
+	}{
+		{
+			Name:      "valid",
+			isValid:   true,
+			rawConfig: expectedConfig,
+		},
+		{
+			Name:      "not valid",
+			isValid:   false,
+			rawConfig: expectedConfig.AppCustom,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			actualConfig := ServiceConfig{}
+
+			ok := actualConfig.UpdateFromRaw(testCase.rawConfig)
+
+			assert.Equal(t, testCase.isValid, ok)
+			if testCase.isValid {
+				assert.Equal(t, expectedConfig, &actualConfig)
+			}
+		})
+	}
+}

--- a/internal/driver/discoverymode.go
+++ b/internal/driver/discoverymode.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package driver
+
+type DiscoveryMode string
+
+const (
+	ModeNetScan   DiscoveryMode = "netscan"
+	ModeMulticast DiscoveryMode = "multicast"
+	ModeBoth      DiscoveryMode = "both"
+)
+
+func (mode DiscoveryMode) IsValid() bool {
+	return mode == ModeNetScan || mode == ModeMulticast || mode == ModeBoth
+}
+
+func (mode DiscoveryMode) IsMulticastEnabled() bool {
+	return mode == ModeMulticast || mode == ModeBoth
+}
+
+func (mode DiscoveryMode) IsNetScanEnabled() bool {
+	return mode == ModeNetScan || mode == ModeBoth
+}

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -84,6 +84,8 @@ func (d *Driver) createDiscoveredDevice(onvifDevice onvif.Device) (sdkModel.Disc
 		return sdkModel.DiscoveredDevice{}, fmt.Errorf("empty EndpointRefAddress for XAddr %s", xaddr)
 	}
 	address, port := addressAndPort(xaddr)
+
+	d.configMu.RLock()
 	device := contract.Device{
 		// Using Xaddr as the temporary name
 		Name: xaddr,
@@ -91,12 +93,13 @@ func (d *Driver) createDiscoveredDevice(onvifDevice onvif.Device) (sdkModel.Disc
 			OnvifProtocol: {
 				Address:            address,
 				Port:               port,
-				AuthMode:           d.config.DefaultAuthMode,
-				SecretPath:         d.config.DefaultSecretPath,
+				AuthMode:           d.config.AppCustom.DefaultAuthMode,
+				SecretPath:         d.config.AppCustom.DefaultSecretPath,
 				EndpointRefAddress: endpointRefAddr,
 			},
 		},
 	}
+	d.configMu.RUnlock()
 
 	devInfo, edgexErr := d.getDeviceInformation(device)
 	if edgexErr != nil {

--- a/internal/driver/pullpointmanager.go
+++ b/internal/driver/pullpointmanager.go
@@ -49,7 +49,11 @@ func (manager *PullPointManager) NewSubscriber(onvifClient *OnvifClient, resourc
 		return errors.NewCommonEdgeXWrapper(edgexErr)
 	}
 
-	onvifDevice, err := manager.newSubscriberOnvifDevice(onvifClient.onvifDevice, *request.MessageTimeout, onvifClient.driverConfig.RequestTimeout)
+	onvifClient.driver.configMu.RLock()
+	requestTimeout := onvifClient.driver.config.AppCustom.RequestTimeout
+	onvifClient.driver.configMu.RUnlock()
+
+	onvifDevice, err := manager.newSubscriberOnvifDevice(onvifClient.onvifDevice, *request.MessageTimeout, requestTimeout)
 	if edgexErr != nil {
 		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to create onvif device for pulling event, %v", err), edgexErr)
 	}

--- a/internal/driver/pullpointsubscriber.go
+++ b/internal/driver/pullpointsubscriber.go
@@ -111,7 +111,7 @@ func (sub *Subscriber) pullMessage() errors.EdgeX {
 		CommandValues: []*sdkModel.CommandValue{cv},
 	}
 
-	sub.onvifClient.asynchCh <- asyncValues
+	sub.onvifClient.driver.asynchCh <- asyncValues
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Closes #23 

## What is the new behavior?
- add config watching functionality
- register provision watchers on discovery (if needed)
- add debounced discovery code from llrp service
- convert toml to object type
- add provision watcher file

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
- Majority of the code was migrated from `device-rfid-llrp-go`.
- In regard to the default provision watchers, I came accross this inconsistency: #74 