### PR TITLE
fix: Remove unused DisconnectDevice func

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -387,13 +387,6 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 	return nil
 }
 
-// DisconnectDevice handles protocol-specific cleanup when a device
-// is removed.
-func (d *Driver) DisconnectDevice(deviceName string, protocols map[string]models.ProtocolProperties) error {
-	d.lc.Warn("Driver's DisconnectDevice function not implemented")
-	return nil
-}
-
 // Stop the protocol-specific DS code to shutdown gracefully, or
 // if the force parameter is 'true', immediately. The driver is responsible
 // for closing any in-use channels, including the channel used to send async


### PR DESCRIPTION
Close #76

Signed-off-by: bruce <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) **not impact the tests**
- [ ] Docs have been added / updated (for bug fixes / features) **not impact the doc**

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #76 


## What is the new behavior?
Since the device-sdk remove the DisconnectDevice func, we can also remove it from driver

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information