### PR TITLE
fix: remove gofrs-uuid

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -155,9 +155,6 @@ https://github.com/IOTechSystems/onvif/blob/master/LICENSE
 beevik/etree 1.1.0 (Unspecified) https://github.com/beevik/etree
 https://github.com/beevik/etree/blob/master/LICENSE
 
-gofrs/uuid 4.0.0 (MIT) https://github.com/gofrs/uuid
-https://github.com/gofrs/uuid/blob/master/LICENSE
-
 gopkg.in/yaml.v3 (MIT) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v3/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/edgexfoundry/device-onvif-camera
 
 require (
-	github.com/IOTechSystems/onvif v0.1.1
+	github.com/IOTechSystems/onvif v0.1.2
 	github.com/edgexfoundry/device-sdk-go/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0
-	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.7.5
 )
@@ -33,7 +33,6 @@ require (
 	github.com/go-playground/validator/v10 v10.10.1 // indirect
 	github.com/go-redis/redis/v7 v7.3.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/consul/api v1.9.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -57,7 +56,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/spiffe/go-spiffe/v2 v2.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zeebo/errs v1.2.2 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ bitbucket.org/bertimus9/systemstat v0.5.0/go.mod h1:EkUWPp8lKFPMXP8vnbpT5JDI0W/s
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/IOTechSystems/onvif v0.1.1 h1:v4Tlets2jAgTJIijN0f/xa1VU5FpxPcEq1FcGvnXGxk=
-github.com/IOTechSystems/onvif v0.1.1/go.mod h1:boBogiF9ZqtGypw3Acd88WdlJ2kR4nkNGZXScZW42ok=
+github.com/IOTechSystems/onvif v0.1.2 h1:vp6Oy9oq1NgaaAq+CeFlz2Q7SszjbrzXtSgdVkSXpMM=
+github.com/IOTechSystems/onvif v0.1.2/go.mod h1:fm6RkIlr9uWJVFLvbGPR7NpmFXDE+PwawSCkQse0Pp4=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
@@ -87,8 +87,6 @@ github.com/go-playground/validator/v10 v10.10.1 h1:uA0+amWMiglNZKZ9FJRKUAe9U3RX9
 github.com/go-playground/validator/v10 v10.10.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-redis/redis/v7 v7.3.0 h1:3oHqd0W7f/VLKBxeYTEpqdMUsmMectngjM9OtoRoIgg=
 github.com/go-redis/redis/v7 v7.3.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
-github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
-github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -9,6 +9,7 @@ package driver
 import (
 	stdErrors "errors"
 	"fmt"
+	"github.com/google/uuid"
 	"net"
 	"os"
 	"strings"
@@ -20,7 +21,6 @@ import (
 	sdkModel "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-	"github.com/gofrs/uuid"
 )
 
 const (
@@ -172,7 +172,7 @@ func mapProbeResults(host, port string, devices []onvif.Device) (res []netscan.P
 // probe message directly over the connection and listening for any responses. Those
 // responses are then converted into a slice of onvif.Device.
 func executeRawProbe(conn net.Conn, params netscan.Params) ([]onvif.Device, error) {
-	probeSOAP := wsdiscovery.BuildProbeMessage(uuid.Must(uuid.NewV4()).String(), nil, nil,
+	probeSOAP := wsdiscovery.BuildProbeMessage(uuid.NewString(), nil, nil,
 		map[string]string{"dn": "http://www.onvif.org/ver10/network/wsdl"})
 
 	addr := conn.RemoteAddr().String()


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

`github.com/gofrs/uuid` is still an indirect dependency due to onvif library.

See: https://github.com/IOTechSystems/onvif/pull/12