### PR TITLE
feat(snap): Add initial snap packaging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  # Maintain dependencies for snap's internal Go modules
+  - package-ecosystem: "gomod"
+    directory: "/snap/local/helper-go"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,8 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test snap
-        # uses: canonical/edgex-snap-testing/test@v2
-        uses: MonicaisHer/edgex-snap-testing/test@EDGEX-475-device-onvif-camera
+        uses: canonical/edgex-snap-testing/test@v2
         with:
           name: device-onvif-camera
           snap: ${{needs.build.outputs.snap}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,32 @@
+name: Snap Testing
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and upload snap
+        id: build
+        # uses: canonical/edgex-snap-testing/build@v2
+        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-475-device-onvif-camera
+    outputs:
+      snap: ${{steps.build.outputs.snap}}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and test snap
+        # uses: canonical/edgex-snap-testing/test@v2
+        uses: MonicaisHer/edgex-snap-testing/test@EDGEX-475-device-onvif-camera
+        with:
+          name: device-onvif-camera
+          snap: ${{needs.build.outputs.snap}}
+

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - name: Build and upload snap
         id: build
-        # uses: canonical/edgex-snap-testing/build@v2
-        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-475-device-onvif-camera
+        uses: canonical/edgex-snap-testing/build@v2
     outputs:
       snap: ${{steps.build.outputs.snap}}
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,12 @@ LintOutput.json
 device-onvif-camera
 run
 
+# snap files
+*.snap
+*.assert
+prime/
+stage/
+parts/
+squashfs-root/
+
 VERSION

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,38 @@
+# EdgeX ONVIF Camera Device Service Snap
+[![edgex-device-onvif-camera](https://snapcraft.io/edgex-device-onvif-cameratt/badge.svg)](https://snapcraft.io/edgex-device-onvif-camera)
+
+This directory contains the snap packaging of the EdgeX ONVIF Camera device service.
+
+The snap is built automatically and published on the Snap Store as [edgex-device-onvif-camera].
+
+For usage instructions, please refer to Device ONVIF Camera section in [Getting Started using Snaps][docs].
+
+## Build from source
+Execute the following command from the top-level directory of this repo:
+```
+snapcraft
+```
+
+This will create a snap package file with `.snap` extension. It can be installed locally by setting the `--dangerous` flag:
+```bash
+sudo snap install --dangerous <snap-file>
+```
+
+The [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) provides additional details.
+
+### Obtain a Secret Store token
+The `edgex-secretstore-token` snap slot makes it possible to automatically receive a token from a locally installed platform snap.
+
+If the snap is built and installed locally, the interface will not auto-connect. You can check the status of the connections by running the `snap connections edgex-device-onvif-camera` command.
+
+To manually connect and obtain a token:
+```bash
+sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-onvif-camera:edgex-secretstore-token
+```
+
+Please refer [here][secret-store-token] for further information.
+
+
+[edgex-device-onvif-camera]: https://snapcraft.io/edgex-device-onvif-camera
+[docs]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#device-onvif-camera
+[secret-store-token]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#secret-store-token

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,5 +1,5 @@
 # EdgeX ONVIF Camera Device Service Snap
-[![edgex-device-onvif-camera](https://snapcraft.io/edgex-device-onvif-cameratt/badge.svg)](https://snapcraft.io/edgex-device-onvif-camera)
+[![edgex-device-onvif-camera](https://snapcraft.io/edgex-device-onvif-camera/badge.svg)](https://snapcraft.io/edgex-device-onvif-camera)
 
 This directory contains the snap packaging of the EdgeX ONVIF Camera device service.
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec $SNAP/bin/helper-go configure

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec $SNAP/bin/helper-go install

--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# convert cmdline to string array
+ARGV=($@)
+
+# grab binary path
+BINPATH="${ARGV[0]}"
+
+# binary name == service name/key
+SERVICE=$(basename "$BINPATH")
+ENV_FILE="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+TAG="edgex-$SERVICE."$(basename "$0")
+
+if [ -f "$ENV_FILE" ]; then
+    logger --tag=$TAG "sourcing $ENV_FILE"
+    set -o allexport
+    source "$ENV_FILE" set
+    set +o allexport 
+fi
+
+exec "$@"

--- a/snap/local/helper-go/Makefile
+++ b/snap/local/helper-go/Makefile
@@ -1,0 +1,8 @@
+build:
+	go build -ldflags="-s -w" -o helper-go
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -f helper-go

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"strings"
+
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+	"github.com/canonical/edgex-snap-hooks/v2/options"
+	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
+)
+
+// configure is called by the main function
+func configure() {
+	log.SetComponentName("configure")
+
+	log.Info("Enabling config options")
+	err := snapctl.Set("app-options", "true").Run()
+	if err != nil {
+		log.Fatalf("could not enable config options: %v", err)
+	}
+
+	log.Info("Processing options")
+	err = options.ProcessAppConfig("device-onvif-camera")
+	if err != nil {
+		log.Fatalf("could not process options: %v", err)
+	}
+
+	// If autostart is not explicitly set, default to "no"
+	// as only example service configuration and profiles
+	// are provided by default.
+	autostart, err := snapctl.Get("autostart").Run()
+	if err != nil {
+		log.Fatalf("Reading config 'autostart' failed: %v", err)
+	}
+	if autostart == "" {
+		log.Debug("autostart is NOT set, initializing to 'no'")
+		autostart = "no"
+	}
+	autostart = strings.ToLower(autostart)
+	log.Debugf("autostart=%s", autostart)
+
+	// services are stopped/disabled by default in the install hook
+	switch autostart {
+	case "true", "yes":
+		err = snapctl.Start("device-usb-camera").Enable().Run()
+		if err != nil {
+			log.Fatalf("Can't start service: %s", err)
+		}
+	case "false", "no":
+		// no action necessary
+	default:
+		log.Fatalf("Invalid value for 'autostart': %s", autostart)
+	}
+}

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/edgexfoundry/device-onvif-camera/hooks
+
+require github.com/canonical/edgex-snap-hooks/v2 v2.3.0
+
+go 1.18

--- a/snap/local/helper-go/go.sum
+++ b/snap/local/helper-go/go.sum
@@ -1,0 +1,12 @@
+github.com/canonical/edgex-snap-hooks/v2 v2.3.0 h1:ddXo8b5AsYjTiZ1APyeHWri0//KfU5qhDwPkyK0TUTc=
+github.com/canonical/edgex-snap-hooks/v2 v2.3.0/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -17,15 +17,22 @@
 package main
 
 import (
+	"os"
+
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 	"github.com/canonical/edgex-snap-hooks/v2/env"
 	"github.com/canonical/edgex-snap-hooks/v2/log"
 )
 
 func installConfig() error {
-	path := "/config/device-onvif-camera/res"
+	resPath := "/config/device-onvif-camera/res"
+	err := os.MkdirAll(env.SnapData+resPath, 0755)
+	if err != nil {
+		return err
+	}
 
-	err := hooks.CopyDir(
+	path := resPath + "/configuration.toml"
+	err = hooks.CopyFile(
 		env.Snap+path,
 		env.SnapData+path)
 	if err != nil {

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	"github.com/canonical/edgex-snap-hooks/v2/env"
+	"github.com/canonical/edgex-snap-hooks/v2/log"
+)
+
+func installConfig() error {
+	path := "/config/device-onvif-camera/res"
+
+	err := hooks.CopyDir(
+		env.Snap+path,
+		env.SnapData+path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installDevices() error {
+	path := "/config/device-onvif-camera/res/devices"
+
+	err := hooks.CopyDir(
+		hooks.Snap+path,
+		hooks.SnapData+path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installDevProfiles() error {
+	path := "/config/device-onvif-camera/res/profiles"
+
+	err := hooks.CopyDir(
+		hooks.Snap+path,
+		hooks.SnapData+path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installProvisionWatchers() error {
+	path := "/config/device-onvif-camera/res/provision_watchers"
+
+	err := hooks.CopyDir(
+		hooks.Snap+path,
+		hooks.SnapData+path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// install is called by the main function
+func install() {
+	log.SetComponentName("install")
+
+	err := installConfig()
+	if err != nil {
+		log.Fatalf("error installing config file: %s", err)
+	}
+
+	err = installDevices()
+	if err != nil {
+		log.Fatalf("error installing devices config: %s", err)
+	}
+
+	err = installDevProfiles()
+	if err != nil {
+		log.Fatalf("error installing device profiles config: %s", err)
+	}
+
+	err = installProvisionWatchers()
+	if err != nil {
+		log.Fatalf("error installing provision watchers: %s", err)
+	}
+}

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	subCommand := os.Args[1]
+	switch subCommand {
+	case "install":
+		install()
+	case "configure":
+		configure()
+	default:
+		panic("Unknown subcommand: " + subCommand)
+	}
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,25 +24,22 @@ plugs:
 apps:
   device-onvif-camera:
     adapter: full
-    command: bin/device-onvif-camera -confdir $SNAP_DATA/config/device-onvif-camera -profile res --registry $CONSUL_ADDR
+    command: bin/device-onvif-camera $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
     command-chain:
       - bin/source-env-file.sh
     environment:
-      CONSUL_ADDR: "consul://localhost:8500"
+      CONFIG_PRO_ARG: "--cp=consul.http://localhost:8500"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-onvif-camera/res"
+      REGISTRY_ARG: "--registry"
       APPCUSTOM_PROVISIONWATCHERDIR: $SNAP_DATA/config/device-onvif-camera/res/provision_watchers
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-onvif-camera/res/profiles
       DEVICE_DEVICESDIR: $SNAP_DATA/config/device-onvif-camera/res/devices
-      SECRETSTORE_SECRETSFILE: $SNAP_DATA/device-onvif-camera/onvif-credentials.json
-      SECRETSTORE_DISABLESCRUBSECRETSFILE: "false"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/device-onvif-camera/secrets-token.json
     daemon: simple
     install-mode: disable
     plugs: [network, network-bind]
 
-
-
 parts:
-
   helper-go:
     source: snap/local/helper-go
     plugin: make
@@ -67,7 +64,7 @@ parts:
       # the version is needed for the build
       cat ./VERSION
 
-      make clean
+      make tidy
       make build
 
       install -DT cmd/device-onvif-camera $SNAPCRAFT_PART_INSTALL/bin/device-onvif-camera

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,118 @@
+name: edgex-device-onvif-camera
+base: core20
+license: Apache-2.0
+adopt-info: metadata
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+grade: stable
+confinement: strict
+
+slots:
+  edgex-secretstore-token:
+    interface: content
+    source:
+      write: [$SNAP_DATA/device-onvif-camera]
+
+plugs:
+  device-config:
+    interface: content
+    target: $SNAP_DATA/config/device-onvif-camera
+
+apps:
+  device-onvif-camera:
+    adapter: full
+    command: bin/device-onvif-camera -confdir $SNAP_DATA/config/device-onvif-camera -profile res --registry $CONSUL_ADDR
+    command-chain:
+      - bin/source-env-file.sh
+    environment:
+      CONSUL_ADDR: "consul://localhost:8500"
+      APPCUSTOM_PROVISIONWATCHERDIR: $SNAP_DATA/config/device-onvif-camera/res/provision_watchers
+      DEVICE_PROFILESDIR: $SNAP_DATA/config/device-onvif-camera/res/profiles
+      DEVICE_DEVICESDIR: $SNAP_DATA/config/device-onvif-camera/res/devices
+      SECRETSTORE_SECRETSFILE: $SNAP_DATA/device-onvif-camera/onvif-credentials.json
+      SECRETSTORE_DISABLESCRUBSECRETSFILE: "false"
+      SECRETSTORE_TOKENFILE: $SNAP_DATA/device-onvif-camera/secrets-token.json
+    daemon: simple
+    install-mode: disable
+    plugs: [network, network-bind]
+
+
+
+parts:
+
+  helper-go:
+    source: snap/local/helper-go
+    plugin: make
+    build-snaps:
+      - go/1.18/stable
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+      install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
+
+  device-onvif-camera:
+    after: [metadata]
+    source: .
+    plugin: make
+    build-packages: [libzmq3-dev, pkg-config]
+    stage-packages: [libzmq5]
+    build-snaps:
+      - go/1.18/stable
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+
+      # the version is needed for the build
+      cat ./VERSION
+
+      make clean
+      make build
+
+      install -DT cmd/device-onvif-camera $SNAPCRAFT_PART_INSTALL/bin/device-onvif-camera
+      
+      RES=$SNAPCRAFT_PART_INSTALL/config/device-onvif-camera/res/
+      mkdir -p $RES
+      cp    cmd/res/configuration.toml $RES
+      cp -r cmd/res/devices $RES
+      cp -r cmd/res/profiles $RES
+      cp -r cmd/res/provision_watchers $RES
+
+      DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-onvif-camera
+      mkdir -p $DOC
+      cp Attribution.txt $DOC/Attribution.txt
+      cp LICENSE $DOC/LICENSE
+
+  local-bin:
+    plugin: dump
+    source: snap/local/bin
+    organize:
+      source-env-file.sh: bin/source-env-file.sh
+
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-device-onvif-camera.metainfo.xml]
+


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features) https://github.com/canonical/edgex-snap-testing/pull/87
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
Test instruction:
1. Install
```
sudo snap install edgex-device-onvif-camera --channel=edge/pr-103
```
2. Configure
seed onvif camera credentials:
```
sudo nano /var/snap/edgex-device-onvif-camera/current/device-onvif-camera/onvif-credentials.json

{
    "secrets": [
        {
            "path": "credentials001",
            "imported": false,
            "secretData": [
                {
                    "key": "username",
                    "value": "your-camera-username"
                },
                                {
                    "key": "password",
                    "value": "your-camera-password"
                },
                {
                    "key": "mode",
                    "value": "usernametoken"
                }
            ]
        }
    ]
}
```
update configuration:
```
/var/snap/edgex-device-onvif-camera/current/config/device-onvif-camera/res/configuration.toml
[AppCustom]
# BaseNotificationURL indicates the device service network location
BaseNotificationURL = "http://192.168.178.1:59984"

# List of IPv4 subnets to perform netscan discovery on, in CIDR format (X.X.X.X/Y)
# separated by commas ex: "192.168.1.0/24,10.0.0.0/24"
DiscoverySubnets = "192.168.178.48/24"

  # AppCustom.CredentialsMap is a map of SecretPath -> Comma separated list of mac addresses
  [AppCustom.CredentialsMap]
  credentials001 = "aa:bb:cc:dd:ee:ff"
```
3. Start
```
sudo snap start edgex-device-onvif-camera
```

## Other information