### PR TITLE
fix: netscan search only for NetworkVideoTransmitter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-onvif-camera
 go 1.18
 
 require (
-	github.com/IOTechSystems/onvif v0.1.3
+	github.com/IOTechSystems/onvif v0.1.4
 	github.com/edgexfoundry/device-sdk-go/v2 v2.3.0-dev.18
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.12
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.14

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ bitbucket.org/bertimus9/systemstat v0.5.0/go.mod h1:EkUWPp8lKFPMXP8vnbpT5JDI0W/s
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/IOTechSystems/onvif v0.1.3 h1:aYVBz9maccOwbWwks++SR/ZXwVKEgLl5xqAfylgDkdU=
-github.com/IOTechSystems/onvif v0.1.3/go.mod h1:fm6RkIlr9uWJVFLvbGPR7NpmFXDE+PwawSCkQse0Pp4=
+github.com/IOTechSystems/onvif v0.1.4 h1:Hlyvdjix/iM+jqpJFvGgJC5KFZcaPUpiyMbdI+Ue7o0=
+github.com/IOTechSystems/onvif v0.1.4/go.mod h1:fm6RkIlr9uWJVFLvbGPR7NpmFXDE+PwawSCkQse0Pp4=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -562,7 +562,7 @@ func (d *Driver) Discover() {
 	var discoveredDevices []sdkModel.DiscoveredDevice
 
 	if discoveryMode.IsMulticastEnabled() {
-		discoveredDevices = append(discoveredDevices, d.discoverMulticast(discoveredDevices)...)
+		discoveredDevices = append(discoveredDevices, d.discoverMulticast()...)
 	}
 
 	if discoveryMode.IsNetScanEnabled() {
@@ -573,7 +573,7 @@ func (d *Driver) Discover() {
 				time.Duration(maxSeconds)*time.Second)
 			defer cancel()
 		}
-		discoveredDevices = append(discoveredDevices, d.discoverNetscan(ctx, discoveredDevices)...)
+		discoveredDevices = append(discoveredDevices, d.discoverNetscan(ctx)...)
 	}
 
 	// pass the discovered devices to the EdgeX SDK to be passed through to the provision watchers
@@ -582,7 +582,9 @@ func (d *Driver) Discover() {
 }
 
 // multicast enable/disable via config option
-func (d *Driver) discoverMulticast(discovered []sdkModel.DiscoveredDevice) []sdkModel.DiscoveredDevice {
+func (d *Driver) discoverMulticast() []sdkModel.DiscoveredDevice {
+	var discovered []sdkModel.DiscoveredDevice
+
 	d.configMu.RLock()
 	discoveryEthernetInterface := d.config.AppCustom.DiscoveryEthernetInterface
 	d.configMu.RUnlock()
@@ -603,7 +605,8 @@ func (d *Driver) discoverMulticast(discovered []sdkModel.DiscoveredDevice) []sdk
 }
 
 // netscan enable/disable via config option
-func (d *Driver) discoverNetscan(ctx context.Context, discovered []sdkModel.DiscoveredDevice) []sdkModel.DiscoveredDevice {
+func (d *Driver) discoverNetscan(ctx context.Context) []sdkModel.DiscoveredDevice {
+	var discovered []sdkModel.DiscoveredDevice
 
 	if len(strings.TrimSpace(d.config.AppCustom.DiscoverySubnets)) == 0 {
 		d.lc.Warn("netscan discovery was called, but DiscoverySubnets are empty!")

--- a/internal/driver/macmapper.go
+++ b/internal/driver/macmapper.go
@@ -113,8 +113,9 @@ func SanitizeMACAddress(mac string) (string, error) {
 
 // macAddressBytewiseReverse returns the byte-wise reverse of the input MAC Address.
 // Examples:
-// 		aa:bb:cc:dd:ee:ff -> ff:ee:dd:cc:bb:aa
-//		12:34:56:78:9a:bc -> bc:9a:78:56:34:12
+//
+//	aa:bb:cc:dd:ee:ff -> ff:ee:dd:cc:bb:aa
+//	12:34:56:78:9a:bc -> bc:9a:78:56:34:12
 func macAddressBytewiseReverse(mac string) (string, error) {
 	var err error
 	if mac, err = SanitizeMACAddress(mac); err != nil {

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -9,12 +9,11 @@ package driver
 import (
 	stdErrors "errors"
 	"fmt"
+	"github.com/google/uuid"
 	"net"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/IOTechSystems/onvif"
 	wsdiscovery "github.com/IOTechSystems/onvif/ws-discovery"
@@ -175,7 +174,7 @@ func mapProbeResults(host, port string, devices []onvif.Device) (res []netscan.P
 // probe message directly over the connection and listening for any responses. Those
 // responses are then converted into a slice of onvif.Device.
 func executeRawProbe(conn net.Conn, params netscan.Params) ([]onvif.Device, error) {
-	probeSOAP := wsdiscovery.BuildProbeMessage(uuid.NewString(), nil, nil,
+	probeSOAP := wsdiscovery.BuildProbeMessage(uuid.NewString(), nil, []string{"dn:NetworkVideoTransmitter"},
 		map[string]string{"dn": "http://www.onvif.org/ver10/network/wsdl"})
 
 	addr := conn.RemoteAddr().String()


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

Related: #134 
Related: #135 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
    - no existing unit tests
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
Upgraded `IOTechSystems/onvif` from v0.1.3 to v0.1.4