### PR TITLE
fix: discovery mode netscan when using docker-compose

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -261,7 +261,7 @@ func (d *Driver) addProvisionWatchers() error {
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		
+
 		filename := filepath.Join(provisionWatcherFolder, file.Name())
 		d.lc.Debugf("processing %s", filename)
 		var watcher dtos.ProvisionWatcher

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -257,7 +257,7 @@ func (d *Driver) addProvisionWatchers() error {
 
 	var errs []error
 	for _, file := range files {
-		//skip all directories, and files that do not end with .json
+		// skip all directories, and files that do not end with .json
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -257,7 +257,7 @@ func (d *Driver) addProvisionWatchers() error {
 
 	var errs []error
 	for _, file := range files {
-		//add by edgego,if existes any dir will skip , or not json file also skip
+		/if existes any dir will skip them , or skip  non-json file
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -257,6 +257,11 @@ func (d *Driver) addProvisionWatchers() error {
 
 	var errs []error
 	for _, file := range files {
+		//add by edgego,if existes any dir will skip , or not json file also skip
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
+			continue
+		}
+		
 		filename := filepath.Join(provisionWatcherFolder, file.Name())
 		d.lc.Debugf("processing %s", filename)
 		var watcher dtos.ProvisionWatcher

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -257,7 +257,7 @@ func (d *Driver) addProvisionWatchers() error {
 
 	var errs []error
 	for _, file := range files {
-		/if existes any dir will skip them , or skip  non-json file
+		//skip all directories, and files that do not end with .json
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -189,7 +189,7 @@ func executeRawProbe(conn net.Conn, params netscan.Params) ([]onvif.Device, erro
 
 	var responses []string
 	buf := make([]byte, bufSize)
-	// keep reading from the connection
+	// keep reading responses from the connection
 	for {
 		n, err := conn.Read(buf)
 		if err != nil {

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -191,7 +191,8 @@ func executeRawProbe(conn net.Conn, params netscan.Params) ([]onvif.Device, erro
 	buf := make([]byte, bufSize)
 	// keep reading from the PacketConn until the read deadline expires or an error occurs
 	for {
-		n, _, err := (conn.(net.PacketConn)).ReadFrom(buf)
+		//n, _, err := (conn.(net.PacketConn)).ReadFrom(buf) //comment by edgego
+		n, err := conn.Read(buf) //add by edgego
 		if err != nil {
 			// ErrDeadlineExceeded is expected once the read timeout is expired
 			if !stdErrors.Is(err, os.ErrDeadlineExceeded) {

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -133,10 +133,10 @@ func (d *Driver) createDiscoveredDevice(onvifDevice onvif.Device) (sdkModel.Disc
 		device.Protocols[OnvifProtocol][LastSeen] = time.Now().Format(time.UnixDate)
 		device.Protocols[OnvifProtocol][FriendlyName] = devInfo.Manufacturer + " " + devInfo.Model
 
-		// Spaces are not allowed in the device name
+		// Spaces and slashes are not allowed in the device name
 		deviceName := fmt.Sprintf("%s-%s-%s",
 			strings.ReplaceAll(devInfo.Manufacturer, " ", "-"),
-			strings.ReplaceAll(strings.ReplaceAll(devInfo.Model, "/", "-"), " ", "-"), //modified by edgego
+			strings.ReplaceAll(strings.ReplaceAll(devInfo.Model, "/", "-"), " ", "-"), 
 			endpointRefAddr)
 
 		netInfo, err := d.getNetworkInterfaces(device)
@@ -189,10 +189,9 @@ func executeRawProbe(conn net.Conn, params netscan.Params) ([]onvif.Device, erro
 
 	var responses []string
 	buf := make([]byte, bufSize)
-	// keep reading from the PacketConn until the read deadline expires or an error occurs
+	// keep reading from the connection
 	for {
-		//n, _, err := (conn.(net.PacketConn)).ReadFrom(buf) //comment by edgego
-		n, err := conn.Read(buf) //add by edgego
+		n, err := conn.Read(buf)
 		if err != nil {
 			// ErrDeadlineExceeded is expected once the read timeout is expired
 			if !stdErrors.Is(err, os.ErrDeadlineExceeded) {

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -136,7 +136,7 @@ func (d *Driver) createDiscoveredDevice(onvifDevice onvif.Device) (sdkModel.Disc
 		// Spaces and slashes are not allowed in the device name
 		deviceName := fmt.Sprintf("%s-%s-%s",
 			strings.ReplaceAll(devInfo.Manufacturer, " ", "-"),
-			strings.ReplaceAll(strings.ReplaceAll(devInfo.Model, "/", "-"), " ", "-"), 
+			strings.ReplaceAll(strings.ReplaceAll(devInfo.Model, "/", "-"), " ", "-"),
 			endpointRefAddr)
 
 		netInfo, err := d.getNetworkInterfaces(device)

--- a/internal/driver/onvifdiscovery.go
+++ b/internal/driver/onvifdiscovery.go
@@ -136,7 +136,7 @@ func (d *Driver) createDiscoveredDevice(onvifDevice onvif.Device) (sdkModel.Disc
 		// Spaces are not allowed in the device name
 		deviceName := fmt.Sprintf("%s-%s-%s",
 			strings.ReplaceAll(devInfo.Manufacturer, " ", "-"),
-			strings.ReplaceAll(devInfo.Model, " ", "-"),
+			strings.ReplaceAll(strings.ReplaceAll(devInfo.Model, "/", "-"), " ", "-"), //modified by edgego
 			endpointRefAddr)
 
 		netInfo, err := d.getNetworkInterfaces(device)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->