### PR TITLE
feat: log raw response when xml unmarshal fails

### DIFF
--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -414,6 +414,8 @@ func (onvifClient *OnvifClient) callOnvifFunction(serviceName, functionName stri
 
 	responseEnvelope, edgexErr := createResponse(function, rsp)
 	if edgexErr != nil {
+		// log the raw response from the camera since it will not be logged further down
+		onvifClient.lc.Debugf("Raw SOAP Response: %v", string(rsp))
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to create '%s' response for the web service '%s'", functionName, serviceName), edgexErr)
 	}
 	res, _ := xml.Marshal(responseEnvelope)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
When unmarshalling an xml soap message from a camera fails, the response message is now logged, to better be able to debug why it failed. This use case first occurred when the onvif library had an incorrect type definition and failed to parse a message.