### PR TITLE
refactor!: Rename path to secret name

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -502,7 +502,7 @@ set_insecure_secret() {
 set_secure_secret() {
     local payload="{
     \"apiVersion\":\"v2\",
-    \"path\": \"${SECRET_NAME}\",
+    \"secretName\": \"${SECRET_NAME}\",
     \"secretData\":[
         {
             \"key\":\"username\",

--- a/doc/credentials.md
+++ b/doc/credentials.md
@@ -59,10 +59,10 @@ See [here](./utility-scripts.md) for the full guide.
 > **Note:** Replace `<secret-name>` with the name of the secret, `<username>` with the username,
 > `<password>` with the password, and `<mode>` with the auth mode.
 
-Set Path to `<device-name>`
+Set SecretName to `<device-name>`
 ```shell
 curl -X PUT --data "<secret-name>" \
-    "http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/<secret-name>/Path"
+    "http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/<secret-name>/SecretName"
 ```
 
 Set username to `<username>`

--- a/doc/getting-started-with-docker-security.md
+++ b/doc/getting-started-with-docker-security.md
@@ -33,7 +33,7 @@ curl --location --request POST 'http://0.0.0.0:59984/api/v2/secret' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "apiVersion":"v2",
-    "path": "bosch",
+    "secretName": "bosch",
     "secretData":[
         {
             "key":"username",

--- a/doc/guides/SimpleStartupGuide.md
+++ b/doc/guides/SimpleStartupGuide.md
@@ -372,8 +372,8 @@ Device discovery is triggered by the device service. Once the device service sta
    curl -X GET http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/AppCustom/CredentialsMap/a?raw=true
    Response [404] 
    Failed! curl returned a status code of '404'
-   Setting InsecureSecret: a/Path
-   curl --data "<redacted>" -X PUT http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/a/Path
+   Setting InsecureSecret: a/SecretName
+   curl --data "<redacted>" -X PUT http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/a/SecretName
    Response [200] true
 
 

--- a/doc/running-guide.md
+++ b/doc/running-guide.md
@@ -236,8 +236,8 @@ Follow these instructions to update devices.
    curl -X GET http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/AppCustom/CredentialsMap/a?raw=true
    Response [404] 
    Failed! curl returned a status code of '404'
-   Setting InsecureSecret: a/Path
-   curl --data "<redacted>" -X PUT http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/a/Path
+   Setting InsecureSecret: a/SecretName
+   curl --data "<redacted>" -X PUT http://localhost:8500/v1/kv/edgex/v3/device-onvif-camera/Writable/InsecureSecrets/a/SecretName
    Response [200] true
 
 


### PR DESCRIPTION
BREAKING CHANGE: Rename path to secret name

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make test
make docker
/compose-builder$ make gen no-secty ds-onvif-camera (this generates docker-compose.yml with latest edgex images)
Replace onvif docker image in docker-compose.yml with your latest image created using make docker from the previous step
/compose-builder$ make up
/bin/configure-subnets.sh without error
/bin/map-credentials.sh without error
no error in device-onvif-camera service log

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->