### PR TITLE
fix: upgrade sdk to fix device cache issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2022-2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 edgeXBuildGoApp (
     project: 'device-onvif-camera',
+    goVersion: '1.18',
     publishSwaggerDocs: true,
     swaggerApiFolders: ['doc/openapi/v2']
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/IOTechSystems/onvif v0.1.5
-	github.com/edgexfoundry/device-sdk-go/v2 v2.3.0
+	github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
 github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v2 v2.3.0 h1:ahmx62BcfbatEOVKbu/6nRFZDsrJgzfv4lUIqdFFJuI=
-github.com/edgexfoundry/device-sdk-go/v2 v2.3.0/go.mod h1:QbA/sWfx6LoyWn/K992LdcB7tnktlPNHK3PtCORlyxI=
+github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3 h1:wmxD96TEUmIivVe+5rF/tXXBdgXKCNdYzvdR/p8sjO8=
+github.com/edgexfoundry/device-sdk-go/v2 v2.3.1-dev.3/go.mod h1:QbA/sWfx6LoyWn/K992LdcB7tnktlPNHK3PtCORlyxI=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0 h1:NCOc5bOz6oX+KuOcv0Rt6BTSDShbg4VmCapXO19IoCM=
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0/go.mod h1:jWZjsy0BaO6+S+Tq111mcrkGKpg6bhTyqngyYcl+70E=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.3.0 h1:VeK7VBiNc/RIR7HXC0ya3fWCmcFQzrSLITPYn87cQsA=


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions

- make test
- make docker
- /compose-builder$ git checkout levski
- /compose-builder$ make pull
- /compose-builder$ make gen no-secty ds-onvif-camera (this generates docker-compose.yml with levski based edgex images)
- Replace onvif service docker image in docker-compose.yml with your latest image created using `make docker` from the previous step
- /compose-builder$ make up
- /bin/configure-subnets.sh without error
- /bin/map-credentials.sh without error
- Onvif devices should be registered in Edgex
- Sending any valid command to the onvif device should be successful
- Restart the onvif docker service
- Re-sending commands to the device as done previously should be successful

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->