### PR TITLE
refactor(snap): Update command and metadata sourcing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,9 @@
 name: edgex-device-onvif-camera
 base: core20
 license: Apache-2.0
-adopt-info: metadata
+summary: EdgeX ONVIF Camera Device Service
+description: Refer to https://snapcraft.io/edgex-device-onvif-camera
+adopt-info: device-onvif-camera
 
 architectures:
   - build-on: amd64
@@ -29,13 +31,10 @@ plugs:
 apps:
   device-onvif-camera:
     adapter: full
-    command: bin/device-onvif-camera $CONFIG_PRO_ARG $CONF_ARG $REGISTRY_ARG
+    command: bin/device-onvif-camera --configDir $SNAP_DATA/config/device-onvif-camera/res --configProvider --registry
     command-chain:
       - bin/source-env-file.sh
     environment:
-      CONFIG_PRO_ARG: "--cp=consul.http://localhost:8500"
-      CONF_ARG: "--configDir=$SNAP_DATA/config/device-onvif-camera/res"
-      REGISTRY_ARG: "--registry"
       DEVICE_PROVISIONWATCHERSDIR: $SNAP_DATA/config/device-onvif-camera/res/provisionwatchers
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-onvif-camera/res/profiles
       DEVICE_DEVICESDIR: $SNAP_DATA/config/device-onvif-camera/res/devices
@@ -56,19 +55,26 @@ parts:
       install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
 
   device-onvif-camera:
-    after: [metadata]
     source: .
     plugin: make
-    build-packages: [pkg-config]
+    build-packages: [git]
     build-snaps:
       - go/1.20/stable
     override-build: |
       cd $SNAPCRAFT_PART_SRC
 
-      # the version is needed for the build
-      cat ./VERSION
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
 
-      make tidy
+      # set the version of the snap
+      snapcraftctl set-version $VERSION
+      
+      # write version to file for the build
+      echo $VERSION > VERSION
+
       make build
 
       install -DT cmd/device-onvif-camera $SNAPCRAFT_PART_INSTALL/bin/device-onvif-camera
@@ -90,30 +96,4 @@ parts:
     source: snap/local/bin
     organize:
       source-env-file.sh: bin/source-env-file.sh
-
-  metadata:
-    plugin: nil
-    source: https://github.com/canonical/edgex-snap-metadata.git
-    source-branch: appstream
-    source-depth: 1
-    override-build: |
-      # install the icon at the default internal path
-      install -DT edgex-snap-icon.png \
-        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
-
-      # change to this project's repo to get the version
-      cd $SNAPCRAFT_PROJECT_DIR
-
-      if git describe ; then
-        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      else
-        VERSION="0.0.0"
-      fi
-      
-      # write version to file for the build
-      echo $VERSION > ./VERSION
-
-      # set the version of this snap
-      snapcraftctl set-version $VERSION
-    parse-info: [edgex-device-onvif-camera.metainfo.xml]
 


### PR DESCRIPTION
- Inline CLIs flags
- Remove unused packages
- Remove external metadata sourcing

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Build snap from this PR:
```
snap install --channel stable --classic snapcraft
snapcraft --use-lxd
# Snapped edgex-device-onvif-camera_3.0.0-dev.20_amd64.snap
```
Start the device:
```
sudo snap install --dangerous ./edgex-device-onvif-camera_3.0.0-dev.20_amd64.snap
sudo snap install edgexfoundry --channel=latest/edge
sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-onvif-camera:edgex-secretstore-token
sudo snap start --enable edgex-device-onvif-camera.device-onvif-camera
```
Check metadata:
```
$ snap info edgex-device-onvif-camera
name:      edgex-device-onvif-camera
summary:   EdgeX ONVIF Camera Device Service
publisher: –
store-url: https://snapcraft.io/edgex-device-onvif-camera
license:   Apache-2.0
description: |
  Refer to https://snapcraft.io/edgex-device-onvif-camera
services:
  edgex-device-onvif-camera.device-onvif-camera: simple, enabled, active
refresh-date: today at 11:10 CET
channels:
  latest/stable:    2.3.0        2022-11-11 (234) 12MB -
  latest/candidate: ↑                                  
  latest/beta:      ↑                                  
  latest/edge:      3.0.0-dev.21 2023-03-17 (465) 12MB -
installed:          3.0.0-dev.20             (x2) 12MB -
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->