### PR TITLE
fix: obsolete code removed

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -80,13 +80,6 @@ func (me MultiErr) Error() string {
 	return strings.Join(strs, "; ")
 }
 
-// EdgeX's Device SDK takes an interface{}
-// and uses a runtime-check to determine that it implements ProtocolDriver,
-// at which point it will abruptly exit without a panic.
-// This restores type-safety by making it so that we can't compile
-// unless we meet the runtime-required interface.
-var _ interfaces.ProtocolDriver = (*Driver)(nil)
-
 // Initialize performs protocol-specific initialization for the device
 // service.
 func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make test
make docker
/compose-builder$ git checkout main
/compose-builder$ make pull
/compose-builder$ make gen no-secty ds-onvif-camera
Replace onvif service docker image in docker-compose.yml with your latest image created using make docker from the previous step
/compose-builder$ make up
/bin/configure-subnets.sh without error
/bin/map-credentials.sh without error
Onvif devices should be registered in Edgex
Sending any valid command to the onvif device should be successful

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->