### PR TITLE
fix: [WIP BUG] Add ProfilesDir & DevicesDir to local config

### DIFF
--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -20,19 +20,22 @@ Service:
   StartupMsg: Camera device service started
 
 # uncomment when running from command-line in hybrid mode with -cp -o flags
-# Registry:
-#   Host: localhost
-
-# Clients:
-#   core-metadata:
-#     Host: localhost # uncomment when running from command-line in hybrid mode
+#Registry:
+# Host: localhost
+#
+#Clients:
+# core-metadata:
+#   Host: localhost # uncomment when running from command-line in hybrid mode
 
 MessageBus:
-  # Host: localhost # uncomment when running from command-line in hybrid mode
+#  Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: device-onvif-camera
 
 Device:
+  # These have common values (currently), but must be here for service local env overrides to apply when customized
+  ProfilesDir: "./res/profiles"
+  DevicesDir: "./res/devices"
   # The location of Provision Watcher yaml files to import when using auto-discovery
   ProvisionWatchersDir: ./res/provisionwatchers
   Discovery:


### PR DESCRIPTION
This is so that the values can be overriden with Envs

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) 
  TBD

## Testing Instructions
Run non-secure EdgeX stack and stop docker version of service if running
Run `make build`
Edit config to uncomment Host values for hybrid mode
Run service locally with `-cp -o` options
Verify profile and devices files loaded
- Excepted profile and device are push to Metadata or are pulled from Metadata
Stop the servicer and run the following exports
- `export DEVICE_DEVICESDIR=./res/junk`
- `export DEVICE_PROFILESDIR=./res/junk`
Run service locally again with `-cp -o` options
Verify the following overrides are logged
```
Variables override of 'Device/DevicesDir' by environment variable: DEVICE_DEVICESDIR=./res/junk"
"Variables override of 'Device/DevicesDir' by environment variable: DEVICE_DEVICESDIR=./res/junk"
```
Verify service fails to bootstrap with the following error:
```
"Failed to load device profiles: failed to read directory -> open /home/lenny/edgex/DEVICE-SERVICES/device-virtual-go/cmd/res/junk: no such file or directory"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->