### PR TITLE
fix: Get command should return server error instead of timeout error

### DIFF
--- a/cmd/res/configuration.yaml
+++ b/cmd/res/configuration.yaml
@@ -45,7 +45,7 @@ Device:
 # Custom configs
 AppCustom:
   # The number of seconds to wait when making an Onvif request before timing out
-  RequestTimeout: 5
+  RequestTimeout: 4
   # The Secret Name of the default credentials to use for devices which do not have MAC Addresses defined, or do not
   # have credentials defined in the CredentialsMap. The magic value of 'NoAuth' here will cause the devices to default
   # to not using any authentication. If authentication is required, it would then need to be manually configured.


### PR DESCRIPTION
Set the default AppCustom.RequestTimeout config to 4 (less than the service request tmieout). Then, the service can reply the proper error content in the response.

Close #256

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core service and device service to check the command should return server error instead of timeout error

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->