### PR TITLE
fix: update secret url to v3 in scripts

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -517,7 +517,7 @@ set_secure_secret() {
     fi
 
     local payload="{
-    \"apiVersion\":\"v2\",
+    \"apiVersion\":\"v3\",
     \"secretName\": \"${SECRET_NAME}\",
     \"secretData\":[
         {
@@ -536,7 +536,7 @@ set_secure_secret() {
 }"
     do_curl "${payload}" \
         -H "Authorization:Bearer ${REST_API_JWT}" \
-        -X POST "${DEVICE_SERVICE_URL}/api/v2/secret"
+        -X POST "${DEVICE_SERVICE_URL}/api/v3/secret"
 }
 
 # helper function to set the secrets using either secure or insecure mode


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Run latest edgex-compose with latest onvif service. Run `./bin/map-credentials.sh`. Expect 200 success.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->