### PR TITLE
feat: implement driver Start command

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 // Copyright (c) 2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -8,8 +8,6 @@
 package driver
 
 import (
-	"encoding/base64"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -66,49 +64,6 @@ func createTestDevice() models.Device {
 
 func createTestDeviceWithProtocols(protocols map[string]models.ProtocolProperties) models.Device {
 	return models.Device{Name: testDeviceName, Protocols: protocols}
-}
-
-func TestParametersFromURLRawQuery(t *testing.T) {
-	parameters := `{ "ProfileToken": "Profile_1" }`
-	base64EncodedStr := base64.StdEncoding.EncodeToString([]byte(parameters))
-	req := sdkModel.CommandRequest{
-		Attributes: map[string]interface{}{
-			URLRawQuery: fmt.Sprintf("%s=%s", jsonObject, base64EncodedStr),
-		},
-	}
-	data, err := parametersFromURLRawQuery(req)
-	require.NoError(t, err)
-	assert.Equal(t, parameters, string(data))
-}
-
-// TestAddressAndPort verifies splitting of address and port from a given string.
-func TestAddressAndPort(t *testing.T) {
-
-	tests := []struct {
-		input           string
-		expectedAddress string
-		expectedPort    string
-	}{
-		{
-			input:           "localhost:80",
-			expectedAddress: "localhost",
-			expectedPort:    "80",
-		},
-		{
-			input:           "localhost",
-			expectedAddress: "localhost",
-			expectedPort:    "80",
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.input, func(t *testing.T) {
-			resultAddress, resultPort := addressAndPort(test.input)
-			assert.Equal(t, test.expectedAddress, resultAddress)
-			assert.Equal(t, test.expectedPort, resultPort)
-		})
-	}
 }
 
 func TestDriver_HandleReadCommands(t *testing.T) {

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -30,7 +30,7 @@ func (me MultiErr) Error() string {
 func addressAndPort(xaddr string) (string, string) {
 	substrings := strings.Split(xaddr, ":")
 	if len(substrings) == 1 {
-		// The port the might be empty from the discovered result, for example <d:XAddrs>http://192.168.12.123/onvif/device_service</d:XAddrs>
+		// The port might be empty from the discovered result, for example <d:XAddrs>http://192.168.12.123/onvif/device_service</d:XAddrs>
 		return substrings[0], "80"
 	} else {
 		return substrings[0], substrings[1]

--- a/internal/driver/util.go
+++ b/internal/driver/util.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package driver
+
+import (
+	"encoding/base64"
+	"fmt"
+	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"net/url"
+	"strings"
+)
+
+type MultiErr []error
+
+//goland:noinspection GoReceiverNames
+func (me MultiErr) Error() string {
+	strs := make([]string, len(me))
+	for i, s := range me {
+		strs[i] = s.Error()
+	}
+
+	return strings.Join(strs, "; ")
+}
+
+func addressAndPort(xaddr string) (string, string) {
+	substrings := strings.Split(xaddr, ":")
+	if len(substrings) == 1 {
+		// The port the might be empty from the discovered result, for example <d:XAddrs>http://192.168.12.123/onvif/device_service</d:XAddrs>
+		return substrings[0], "80"
+	} else {
+		return substrings[0], substrings[1]
+	}
+}
+
+func attributeByKey(attributes map[string]interface{}, key string) (attr string, err errors.EdgeX) {
+	val, ok := attributes[key]
+	if !ok {
+		return "", errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("attribute %s not exists", key), nil)
+	}
+	attr = fmt.Sprint(val)
+	return attr, nil
+}
+
+func parametersFromURLRawQuery(req sdkModel.CommandRequest) ([]byte, errors.EdgeX) {
+	values, err := url.ParseQuery(fmt.Sprint(req.Attributes[URLRawQuery]))
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse get command parameter for resource '%s'", req.DeviceResourceName), err)
+	}
+	param, exists := values[jsonObject]
+	if !exists || len(param) == 0 {
+		return []byte{}, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(param[0])
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to decode '%v' parameter for resource '%s', the value should be json object with base64 encoded", jsonObject, req.DeviceResourceName), err)
+	}
+	return data, nil
+}

--- a/internal/driver/util_test.go
+++ b/internal/driver/util_test.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package driver
+
+import (
+	"encoding/base64"
+	"fmt"
+	sdkModel "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParametersFromURLRawQuery(t *testing.T) {
+	parameters := `{ "ProfileToken": "Profile_1" }`
+	base64EncodedStr := base64.StdEncoding.EncodeToString([]byte(parameters))
+	req := sdkModel.CommandRequest{
+		Attributes: map[string]interface{}{
+			URLRawQuery: fmt.Sprintf("%s=%s", jsonObject, base64EncodedStr),
+		},
+	}
+	data, err := parametersFromURLRawQuery(req)
+	require.NoError(t, err)
+	assert.Equal(t, parameters, string(data))
+}
+
+// TestAddressAndPort verifies splitting of address and port from a given string.
+func TestAddressAndPort(t *testing.T) {
+
+	tests := []struct {
+		input           string
+		expectedAddress string
+		expectedPort    string
+	}{
+		{
+			input:           "localhost:80",
+			expectedAddress: "localhost",
+			expectedPort:    "80",
+		},
+		{
+			input:           "localhost",
+			expectedAddress: "localhost",
+			expectedPort:    "80",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.input, func(t *testing.T) {
+			resultAddress, resultPort := addressAndPort(test.input)
+			assert.Equal(t, test.expectedAddress, resultAddress)
+			assert.Equal(t, test.expectedPort, resultPort)
+		})
+	}
+}


### PR DESCRIPTION
It seems like GitHub wants to do some funky things with the change detection because of my reordering of functions. Here is a breakdown of the changes:

- Moved a chunk of code from Initialize into Start
- Added locking and clearing of clients on Stop()
- Moved non-driver functions to util.go along with their tests
- re-ordered the functions in driver.go to make more sense. (initialize, start, stop all together, etc.)

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

Fixes #308 