### PR TITLE
refactor!: updated Snapshot api to get profile token input.

### DIFF
--- a/cmd/res/profiles/camera.yaml
+++ b/cmd/res/profiles/camera.yaml
@@ -825,3 +825,10 @@ deviceCommands:
     resourceOperations:
       - { deviceResource: "Profiles" }
       - { deviceResource: "StreamUri" }
+  -
+    name: "SnapshotFunction"
+    readWrite: "R"
+    isHidden: false
+    resourceOperations:
+      - { deviceResource: "Profiles" }
+      - { deviceResource: "Snapshot" }

--- a/cmd/res/profiles/camera.yaml
+++ b/cmd/res/profiles/camera.yaml
@@ -818,17 +818,3 @@ deviceCommands:
     resourceOperations:
       - { deviceResource: "MetadataConfiguration" }
       - { deviceResource: "MetadataConfigurationOptions" }
-  -
-    name: "VideoStream"
-    readWrite: "R"
-    isHidden: false
-    resourceOperations:
-      - { deviceResource: "Profiles" }
-      - { deviceResource: "StreamUri" }
-  -
-    name: "SnapshotFunction"
-    readWrite: "R"
-    isHidden: false
-    resourceOperations:
-      - { deviceResource: "Profiles" }
-      - { deviceResource: "Snapshot" }

--- a/doc/openapi/v2/device-onvif-camera.yaml
+++ b/doc/openapi/v2/device-onvif-camera.yaml
@@ -3597,6 +3597,37 @@ paths:
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
       parameters:
+      - name: jsonObject
+        in: query
+        schema:
+          type: string
+        example: eyJQcm9maWxlVG9rZW4iOiJwcm9maWxlXzEifQ==
+        description: |
+          **Format:**<br/>
+          This field is a Base64 encoded json string.
+
+          **JSON Schema:**
+          ```yaml
+          {
+            "ProfileToken": "<ProfileToken>"
+          }
+          ```
+
+          **Field Descriptions:**
+            - **ProfileToken** _[string]_
+          <br/>    The ProfileToken element indicates the media profile to use and will define the source and dimensions of the snapshot.
+
+
+          **Schema Reference:** [media_GetSnapshotUri](#media_GetSnapshotUri)
+
+          **Example JSON:**<br/>
+          > _Note: This value must be encoded to base64!_
+
+          ```json
+          {
+            "ProfileToken": "profile_1"
+          }
+          ```
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
         '200':

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -3794,7 +3794,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -3810,6 +3810,12 @@
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
 								"Snapshot"
+							],
+							"query": [
+								{
+									"key": "jsonObject",
+									"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
+								}
 							]
 						},
 						"description": "This request returns a snapshot of the video stream at the time the command is given.\n\nIt is returned in a binary format."
@@ -3821,7 +3827,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -3837,6 +3843,12 @@
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
 										"Snapshot"
+									],
+									"query": [
+										{
+											"key": "jsonObject",
+											"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
+										}
 									]
 								}
 							},

--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -417,12 +417,9 @@ func (onvifClient *OnvifClient) callSubscribeCameraEventFunction(resourceName, s
 
 // callGetSnapshotFunction returns a snapshot from the camera as a slice of bytes
 // The implementation can refer to https://github.com/edgexfoundry/device-camera-go/blob/5c4f34d1d59b8e25e1a6316661d463e2495d45fe/internal/driver/onvifclient.go#L119
-func (onvifClient *OnvifClient) callGetSnapshotFunction(profileToken []byte) ([]byte, errors.EdgeX) {
-	if len(profileToken) == 0 {
-		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "no profile token in request", nil)
-	}
-
-	respContent, edgexErr := onvifClient.callOnvifFunction(onvif.MediaWebService, onvif.GetSnapshotUri, profileToken)
+func (onvifClient *OnvifClient) callGetSnapshotFunction(data []byte) ([]byte, errors.EdgeX) {
+	// data contains profile token json object
+	respContent, edgexErr := onvifClient.callOnvifFunction(onvif.MediaWebService, onvif.GetSnapshotUri, data)
 	if edgexErr != nil {
 		return nil, errors.NewCommonEdgeXWrapper(edgexErr)
 	}

--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -27,7 +27,6 @@ import (
 	onvifdevice "github.com/IOTechSystems/onvif/device"
 	"github.com/IOTechSystems/onvif/gosoap"
 	"github.com/IOTechSystems/onvif/media"
-	xsdOnvif "github.com/IOTechSystems/onvif/xsd/onvif"
 )
 
 const (
@@ -314,7 +313,7 @@ func (onvifClient *OnvifClient) callCustomFunction(resourceName, functionName st
 			onvifClient.baseNotificationManager.UnsubscribeAll()
 		}()
 	case GetSnapshot:
-		res, edgexErr := onvifClient.callGetSnapshotFunction()
+		res, edgexErr := onvifClient.callGetSnapshotFunction(data)
 		if edgexErr != nil {
 			return nil, errors.NewCommonEdgeXWrapper(edgexErr)
 		}
@@ -418,25 +417,12 @@ func (onvifClient *OnvifClient) callSubscribeCameraEventFunction(resourceName, s
 
 // callGetSnapshotFunction returns a snapshot from the camera as a slice of bytes
 // The implementation can refer to https://github.com/edgexfoundry/device-camera-go/blob/5c4f34d1d59b8e25e1a6316661d463e2495d45fe/internal/driver/onvifclient.go#L119
-func (onvifClient *OnvifClient) callGetSnapshotFunction() ([]byte, errors.EdgeX) {
-	// Get the token from the profile
-	respContent, edgexErr := onvifClient.callOnvifFunction(onvif.MediaWebService, onvif.GetProfiles, nil)
-	if edgexErr != nil {
-		return nil, errors.NewCommonEdgeXWrapper(edgexErr)
+func (onvifClient *OnvifClient) callGetSnapshotFunction(profileToken []byte) ([]byte, errors.EdgeX) {
+	if len(profileToken) == 0 {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "no profile token in request", nil)
 	}
-	profilesResp, ok := respContent.(*media.GetProfilesResponse)
-	if !ok {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("invalid GetProfilesResponse of type %T for the camera %s", respContent, onvifClient.DeviceName), nil)
-	}
-	if len(profilesResp.Profiles) == 0 {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "no onvif profiles found", nil)
-	}
-	requestData, edgexErr := snapshotUriRequestData(profilesResp.Profiles[0].Token)
-	if edgexErr != nil {
-		return nil, errors.NewCommonEdgeXWrapper(edgexErr)
-	}
-	// Get the snapshot uri
-	respContent, edgexErr = onvifClient.callOnvifFunction(onvif.MediaWebService, onvif.GetSnapshotUri, requestData)
+
+	respContent, edgexErr := onvifClient.callOnvifFunction(onvif.MediaWebService, onvif.GetSnapshotUri, profileToken)
 	if edgexErr != nil {
 		return nil, errors.NewCommonEdgeXWrapper(edgexErr)
 	}
@@ -460,17 +446,6 @@ func (onvifClient *OnvifClient) callGetSnapshotFunction() ([]byte, errors.EdgeX)
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("http request for image failed with status %v, %s", resp.StatusCode, string(buf)), nil)
 	}
 	return buf, nil
-}
-
-func snapshotUriRequestData(profileToken xsdOnvif.ReferenceToken) ([]byte, errors.EdgeX) {
-	req := media.GetSnapshotUri{
-		ProfileToken: profileToken,
-	}
-	data, err := json.Marshal(req)
-	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to marshal GetSnapshotUri request", err)
-	}
-	return data, nil
 }
 
 func (onvifClient *OnvifClient) callOnvifFunction(serviceName, functionName string, data []byte) (interface{}, errors.EdgeX) {

--- a/internal/driver/onvifclient.go
+++ b/internal/driver/onvifclient.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 // Copyright (c) 2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
BREAKING CHANGE: Making Snapshot command consistent by requiring the request to have profile token to provide snapshot response.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make test
make docker
/compose-builder$ git checkout main
/compose-builder$ make pull
/compose-builder$ make gen no-secty ds-onvif-camera
Replace onvif service docker image in docker-compose.yml with your latest image created using make docker from the previous step
/compose-builder$ make up
/bin/configure-subnets.sh without error
/bin/map-credentials.sh without error
Onvif devices should be registered in Edgex
Get the updated postman collection and env from the doc folder, update the env with the names of onvif cameras and execute `Snapshot` command with different profiles or no profiles and test.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->