### PR TITLE
refactor!: prefix some commands with onvif service name and add SnapshotUri

### DIFF
--- a/cmd/res/profiles/camera.yaml
+++ b/cmd/res/profiles/camera.yaml
@@ -203,9 +203,9 @@ deviceResources:
       readWrite: "RW"
 
   # Video Streaming
-  - name: "Profiles"
+  - name: "MediaProfiles"
     isHidden: false
-    description: "Camera Profiles"
+    description: "Camera Media Profiles"
     attributes:
       service: "Media"
       getFunction: "GetProfiles"
@@ -231,6 +231,15 @@ deviceResources:
       valueType: "Binary"
       readWrite: "R"
       mediaType: "image/jpeg"
+  - name: "SnapshotUri"
+    isHidden: false
+    description: "Camera Snapshot Uri"
+    attributes:
+      service: "Media"
+      getFunction: "GetSnapshotUri"
+    properties:
+      valueType: "Object"
+      readWrite: "R"
 
   # Video Encoder Configuration
   - name: "VideoEncoderConfigurations"
@@ -303,7 +312,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "RW"
-  - name: "Scopes"
+  - name: "DiscoveryScopes"
     isHidden: false
     description: "Camera discovery scopes"
     attributes:
@@ -313,7 +322,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "RW"
-  - name: "AddScopes"
+  - name: "AddDiscoveryScopes"
     isHidden: false
     description: "Add camera discovery scopes"
     attributes:
@@ -322,7 +331,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "RemoveScopes"
+  - name: "RemoveDiscoveryScopes"
     isHidden: false
     description: "Remove camera discovery scopes"
     attributes:
@@ -342,7 +351,7 @@ deviceResources:
       readWrite: "R"
 
   # PTZ Configuration
-  - name: "Nodes"
+  - name: "PTZNodes"
     isHidden: false
     description: "Get the descriptions of the available PTZ Nodes."
     attributes:
@@ -351,7 +360,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "Node"
+  - name: "PTZNode"
     isHidden: false
     description: "Get a specific PTZ Node identified by a reference token or a name."
     attributes:
@@ -360,7 +369,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "Configurations"
+  - name: "PTZConfigurations"
     isHidden: false
     description: "Get all the existing PTZ configurations from the device."
     attributes:
@@ -369,7 +378,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "Configuration"
+  - name: "PTZConfiguration"
     isHidden: false
     description: "Get or set a specific PTZ configuration from the device."
     attributes:
@@ -379,7 +388,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "RW"
-  - name: "ConfigurationOptions"
+  - name: "PTZConfigurationOptions"
     isHidden: false
     description: "List supported coordinate systems including their range limitations."
     attributes:
@@ -408,7 +417,7 @@ deviceResources:
       readWrite: "W"
 
   # PTZ Actuation
-  - name: "AbsoluteMove"
+  - name: "PTZAbsoluteMove"
     isHidden: false
     description: "Operation to move pan,tilt or zoom to a absolute destination."
     attributes:
@@ -417,7 +426,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "RelativeMove"
+  - name: "PTZRelativeMove"
     isHidden: false
     description: "Operation for Relative Pan/Tilt and Zoom Move."
     attributes:
@@ -426,7 +435,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "ContinuousMove"
+  - name: "PTZContinuousMove"
     isHidden: false
     description: "Operation for continuous Pan/Tilt and Zoom movements."
     attributes:
@@ -435,7 +444,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "Stop"
+  - name: "PTZStop"
     isHidden: false
     description: "Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type."
     attributes:
@@ -444,7 +453,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "Status"
+  - name: "PTZStatus"
     isHidden: false
     description: "Operation to request PTZ status for the Node in the selected profile."
     attributes:
@@ -455,7 +464,7 @@ deviceResources:
       readWrite: "R"
 
   # PTZ Preset
-  - name: "Preset"
+  - name: "PTZPreset"
     isHidden: false
     description: "The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation."
     attributes:
@@ -464,7 +473,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "Presets"
+  - name: "PTZPresets"
     isHidden: false
     description: "Operation to request all PTZ presets for the PTZNode in the selected profile."
     attributes:
@@ -473,7 +482,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "R"
-  - name: "GotoPreset"
+  - name: "PTZGotoPreset"
     isHidden: false
     description: "Operation to go to a saved preset position for the PTZNode in the selected profile."
     attributes:
@@ -482,7 +491,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "RemovePreset"
+  - name: "PTZRemovePreset"
     isHidden: false
     description: "Operation to remove a PTZ preset for the Node in the selected profile. "
     attributes:
@@ -493,7 +502,7 @@ deviceResources:
       readWrite: "W"
 
   # PTZ Home Position
-  - name: "GotoHomePosition"
+  - name: "PTZGotoHomePosition"
     isHidden: false
     description: "Operation to move the PTZ device to it's home position."
     attributes:
@@ -502,7 +511,7 @@ deviceResources:
     properties:
       valueType: "Object"
       readWrite: "W"
-  - name: "HomePosition"
+  - name: "PTZHomePosition"
     isHidden: false
     description: "Operation to save current position as the home position."
     attributes:
@@ -513,7 +522,7 @@ deviceResources:
       readWrite: "W"
 
   # PTZ Auxiliary Operations
-  - name: "SendAuxiliaryCommand"
+  - name: "PTZSendAuxiliaryCommand"
     isHidden: false
     description: "Operation to send auxiliary commands to the PTZ device mapped by the PTZNode in the selected profile."
     attributes:
@@ -601,7 +610,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "R"
 
-  - name: "AnalyticsConfigurations"
+  - name: "Media2AnalyticsConfigurations"
     isHidden: false
     description: "Lists all existing video analytics configurations for a device."
     attributes:
@@ -611,7 +620,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "R"
 
-  - name: "AddConfiguration"
+  - name: "Media2AddConfiguration"
     isHidden: false
     description: "Adds one or more Configurations to an existing media profile."
     attributes:
@@ -621,7 +630,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "W"
 
-  - name: "RemoveConfiguration"
+  - name: "Media2RemoveConfiguration"
     isHidden: false
     description: "Removes the listed configurations from an existing media profile. "
     attributes:
@@ -684,7 +693,7 @@ deviceResources:
       readWrite: "R"
 
   # Rule configuration
-  - name: "SupportedRules"
+  - name: "AnalyticsSupportedRules"
     isHidden: false
     description: "List all rules that are supported by the given VideoAnalyticsConfiguration."
     attributes:
@@ -694,7 +703,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "R"
 
-  - name: "Rules"
+  - name: "AnalyticsRules"
     isHidden: false
     description: "Get or set one or more rules of a VideoAnalyticsConfiguration."
     attributes:
@@ -705,7 +714,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "RW"
 
-  - name: "CreateRules"
+  - name: "AnalyticsCreateRules"
     isHidden: false
     description: "Add one or more rules to an existing VideoAnalyticsConfiguration."
     attributes:
@@ -715,7 +724,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "W"
 
-  - name: "DeleteRules"
+  - name: "AnalyticsDeleteRules"
     isHidden: false
     description: "Remove one or more rules from a VideoAnalyticsConfiguration."
     attributes:
@@ -725,7 +734,7 @@ deviceResources:
       valueType: "Object"
       readWrite: "W"
 
-  - name: "RuleOptions"
+  - name: "AnalyticsRuleOptions"
     isHidden: false
     description: "Return the options for the supported rules that specify an Option attribute."
     attributes:

--- a/doc/openapi/v2/device-onvif-camera.yaml
+++ b/doc/openapi/v2/device-onvif-camera.yaml
@@ -21,7 +21,7 @@ tags:
 - name: Video Encoder Configuration
 - name: PTZ
 - name: PTZ - Capabilities
-- name: PTZ - PTZConfiguration
+- name: PTZ - Configuration
 - name: PTZ - Actuation
 - name: PTZ - PTZPreset
 - name: PTZ - Home Position
@@ -4537,7 +4537,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurations:
     get:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'PTZ: GetConfigurations'
       description: |-
         Get all the existing PTZConfigurations from the device.  
@@ -4631,7 +4631,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfiguration:
     get:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'PTZ: GetConfiguration'
       description: |-
         Get a specific PTZconfiguration from the device, identified by its reference token or name.
@@ -4757,7 +4757,7 @@ paths:
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfiguration
     put:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'PTZ: SetConfiguration'
       description: |-
         Set/update a existing PTZConfiguration on the device.
@@ -4813,7 +4813,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurationOptions:
     get:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'PTZ: GetConfigurationOptions'
       description: |-
         List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node.
@@ -4976,7 +4976,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddPTZConfiguration:
     put:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'Media: AddPTZConfiguration'
       description: |-
         Add a new PTZConfiguration on the device.
@@ -5023,7 +5023,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemovePTZConfiguration:
     put:
       tags:
-      - PTZ - PTZConfiguration
+      - PTZ - Configuration
       summary: 'Media: RemovePTZConfiguration'
       description: |-
         Remove a PTZConfiguration on the device.

--- a/doc/openapi/v2/device-onvif-camera.yaml
+++ b/doc/openapi/v2/device-onvif-camera.yaml
@@ -21,9 +21,9 @@ tags:
 - name: Video Encoder Configuration
 - name: PTZ
 - name: PTZ - Capabilities
-- name: PTZ - Configuration
+- name: PTZ - PTZConfiguration
 - name: PTZ - Actuation
-- name: PTZ - Preset
+- name: PTZ - PTZPreset
 - name: PTZ - Home Position
 - name: PTZ - Auxiliary
 - name: Event Handling
@@ -824,7 +824,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetDiscoveryMode
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddScopes:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddDiscoveryScopes:
     put:
       tags:
       - Auto Discovery
@@ -850,13 +850,13 @@ paths:
           application/json:
             schema:
               properties:
-                AddScopes:
+                AddDiscoveryScopes:
                   $ref: '#/components/schemas/device_AddScopes'
               required:
-              - AddScopes
+              - AddDiscoveryScopes
               type: object
             example:
-              AddScopes:
+              AddDiscoveryScopes:
                 ScopeItem:
                 - http//:123
       parameters:
@@ -871,7 +871,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.AddScopes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Scopes:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DiscoveryScopes:
     get:
       tags:
       - Auto Discovery
@@ -928,13 +928,13 @@ paths:
                   id: 05f573f4-0836-45ad-b9ba-c393f9927586
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Scopes
+                  sourceName: DiscoveryScopes
                   origin: 1659659228090509000
                   readings:
                   - id: ea858652-cb16-432c-bf45-f9785cd00d85
                     origin: 1659659228090509000
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Scopes
+                    resourceName: DiscoveryScopes
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -983,13 +983,13 @@ paths:
           application/json:
             schema:
               properties:
-                Scopes:
+                DiscoveryScopes:
                   $ref: '#/components/schemas/device_SetScopes'
               required:
-              - Scopes
+              - DiscoveryScopes
               type: object
             example:
-              Scopes:
+              DiscoveryScopes:
                 Scopes:
                 - http//:123
       parameters:
@@ -1004,7 +1004,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetScopes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveScopes:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveDiscoveryScopes:
     put:
       tags:
       - Auto Discovery
@@ -1030,13 +1030,13 @@ paths:
           application/json:
             schema:
               properties:
-                RemoveScopes:
+                RemoveDiscoveryScopes:
                   $ref: '#/components/schemas/device_RemoveScopes'
               required:
-              - RemoveScopes
+              - RemoveDiscoveryScopes
               type: object
             example:
-              RemoveScopes:
+              RemoveDiscoveryScopes:
                 ScopeItem:
                 - onvif://www.onvif.org/name/Geovision
       parameters:
@@ -1060,13 +1060,13 @@ paths:
                 message: >-
                   request failed, status code: 500, err:
                   {"apiVersion":"v3","message":"error writing DeviceResourece
-                  RemoveScopes for
+                  RemoveDiscoveryScopes for
                   Intel-SimCamera-003caffe-6392-4bb2-a5a4-f027d2e89ee1 -\u003e
                   failed to execute write command, \u003cnil\u003e -\u003e
-                  invalid request for the function 'RemoveScopes' of web service
-                  'Device'. Onvif error: fault reason: Trying to Remove scope
-                  which does not exist, fault detail: , fault code: s:Sender
-                  ter:InvalidArgVal ter:NoScope","statusCode":500}
+                  invalid request for the function 'RemoveDiscoveryScopes' of
+                  web service 'Device'. Onvif error: fault reason: Trying to
+                  Remove scope which does not exist, fault detail: , fault code:
+                  s:Sender ter:InvalidArgVal ter:NoScope","statusCode":500}
                 statusCode: 500
         '200': *id006
         '400': *id001
@@ -3125,7 +3125,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.RemoveMetadataConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Profiles:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MediaProfiles:
     get:
       tags:
       - Video Streaming
@@ -3179,13 +3179,13 @@ paths:
                   id: e6560b52-1952-4d66-9f53-3cf27d48b3c0
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Profiles
+                  sourceName: MediaProfiles
                   origin: 1659656314715442700
                   readings:
                   - id: 5c7bc03c-308f-4b2c-8bc9-2e59da7d6f65
                     origin: 1659656314715442700
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Profiles
+                    resourceName: MediaProfiles
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -3669,6 +3669,110 @@ paths:
         '423': *id003
         '500': *id004
         '503': *id005
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SnapshotUri:
+    get:
+      tags:
+      - Video Streaming
+      summary: 'Media: GetSnapshotUri'
+      parameters:
+      - name: jsonObject
+        in: query
+        schema:
+          type: string
+        example: eyJQcm9maWxlVG9rZW4iOiJwcm9maWxlXzEifQ==
+        description: |
+          **Format:**<br/>
+          This field is a Base64 encoded json string.
+
+          **JSON Schema:**
+          ```yaml
+          {
+            "ProfileToken": "<ProfileToken>"
+          }
+          ```
+
+          **Field Descriptions:**
+            - **ProfileToken** _[string]_
+          <br/>    The ProfileToken element indicates the media profile to use and will define the source and dimensions of the snapshot.
+
+
+          **Schema Reference:** [media_GetSnapshotUri](#media_GetSnapshotUri)
+
+          **Example JSON:**<br/>
+          > _Note: This value must be encoded to base64!_
+
+          ```json
+          {
+            "ProfileToken": "profile_1"
+          }
+          ```
+      - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
+      responses:
+        '200':
+          description: OK
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                example: application/json
+            X-Correlation-Id:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/ObjectEventResponse'
+                - properties:
+                    event:
+                      properties:
+                        readings:
+                          items:
+                            properties:
+                              objectValue:
+                                $ref: '#/components/schemas/media_GetSnapshotUriResponse'
+              example:
+                apiVersion: v3
+                statusCode: 200
+                event:
+                  apiVersion: v3
+                  id: 1a79ee51-c137-49b6-b884-a5450323850a
+                  deviceName: >-
+                    HIKVISION-DS-2DE2A404IW-DE3-099f4000-4d50-11b4-82c8-c06ded544d67
+                  profileName: onvif-camera
+                  sourceName: SnapshotUri
+                  origin: 1683762930988014800
+                  readings:
+                  - id: de3e7c40-d705-4303-987f-d0b0feeffd0f
+                    origin: 1683762930988014800
+                    deviceName: >-
+                      HIKVISION-DS-2DE2A404IW-DE3-099f4000-4d50-11b4-82c8-c06ded544d67
+                    resourceName: SnapshotUri
+                    profileName: onvif-camera
+                    valueType: Object
+                    value: ''
+                    objectValue:
+                      MediaUri:
+                        Uri: http://10.0.0.165/onvif-http/snapshot?Profile_1
+                        InvalidAfterConnect: false
+                        InvalidAfterReboot: false
+                        Timeout: PT0S
+        '400': *id001
+        '404': *id002
+        '423': *id003
+        '500': *id004
+        '503': *id005
+      externalDocs:
+        description: Onvif Specification
+        url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetSnapshotUri
+      description: "A client uses the GetSnapshotUri command to obtain a JPEG snapshot\
+        \ from the\ndevice. The returned URI shall remain valid indefinitely even\
+        \ if the profile is changed. The\nValidUntilConnect, ValidUntilReboot and\
+        \ Timeout Parameter shall be set accordingly\n(ValidUntilConnect=false, ValidUntilReboot=false,\
+        \ timeout=PT0S). The URI can be used for\nacquiring a JPEG image through a\
+        \ HTTP GET operation. The image encoding will always be\nJPEG regardless of\
+        \ the encoding setting in the media profile. The Jpeg settings\n(like resolution\
+        \ or quality) may be taken from the profile if suitable. The provided\nimage\
+        \ will be updated automatically and independent from calls to GetSnapshotUri."
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/VideoEncoderConfigurations:
     get:
       tags:
@@ -4133,7 +4237,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetVideoEncoderConfigurationOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Nodes:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNodes:
     get:
       tags:
       - PTZ - Capabilities
@@ -4189,13 +4293,13 @@ paths:
                   id: dfe1b38e-1590-43c4-ab12-432ed5219476
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Nodes
+                  sourceName: PTZNodes
                   origin: 1659656363928092200
                   readings:
                   - id: a47fe9e2-b007-4b5e-891b-3d50062b468f
                     origin: 1659656363928092200
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Nodes
+                    resourceName: PTZNodes
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -4267,7 +4371,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetNodes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Node:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNode:
     get:
       tags:
       - PTZ - Capabilities
@@ -4352,13 +4456,13 @@ paths:
                   id: 713edf3b-f049-456b-8f3b-4a2dccca683f
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Node
+                  sourceName: PTZNode
                   origin: 1659656370279599600
                   readings:
                   - id: 42af41ee-f72d-4f0c-95cf-0e8326f6d154
                     origin: 1659656370279599600
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Node
+                    resourceName: PTZNode
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -4430,10 +4534,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetNode
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Configurations:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurations:
     get:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'PTZ: GetConfigurations'
       description: |-
         Get all the existing PTZConfigurations from the device.  
@@ -4486,13 +4590,13 @@ paths:
                   id: b46d0e1e-f173-4bf0-8e35-984395952b09
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Configurations
+                  sourceName: PTZConfigurations
                   origin: 1659656376998679000
                   readings:
                   - id: edf84087-d700-4967-bf5a-3e76e3c8ec18
                     origin: 1659656376998679000
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Configurations
+                    resourceName: PTZConfigurations
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -4524,10 +4628,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Configuration:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfiguration:
     get:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'PTZ: GetConfiguration'
       description: |-
         Get a specific PTZconfiguration from the device, identified by its reference token or name.
@@ -4613,13 +4717,13 @@ paths:
                   id: 13f39ebb-cde4-4d99-bbc2-b207c4a40ca3
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Configuration
+                  sourceName: PTZConfiguration
                   origin: 1659656383599131400
                   readings:
                   - id: 3a5e5c97-268a-4c84-ae79-f51ada66889e
                     origin: 1659656383599131400
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Configuration
+                    resourceName: PTZConfiguration
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -4653,7 +4757,7 @@ paths:
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfiguration
     put:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'PTZ: SetConfiguration'
       description: |-
         Set/update a existing PTZConfiguration on the device.
@@ -4676,13 +4780,13 @@ paths:
           application/json:
             schema:
               properties:
-                Configuration:
+                PTZConfiguration:
                   $ref: '#/components/schemas/ptz_SetConfiguration'
               required:
-              - Configuration
+              - PTZConfiguration
               type: object
             example:
-              Configuration:
+              PTZConfiguration:
                 PTZConfiguration:
                   Token: PROFILE_3263078452
                   NodeToken: PTZNODE_3
@@ -4706,10 +4810,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/ConfigurationOptions:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurationOptions:
     get:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'PTZ: GetConfigurationOptions'
       description: |-
         List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node.
@@ -4791,13 +4895,13 @@ paths:
                   id: 418fbbf5-6628-4033-8d7b-0811968dcee8
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: ConfigurationOptions
+                  sourceName: PTZConfigurationOptions
                   origin: 1659671766926306000
                   readings:
                   - id: 7ceb7891-b7af-4cfe-9bbb-2d0fb3bead14
                     origin: 1659671766926306000
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: ConfigurationOptions
+                    resourceName: PTZConfigurationOptions
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -4872,7 +4976,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddPTZConfiguration:
     put:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'Media: AddPTZConfiguration'
       description: |-
         Add a new PTZConfiguration on the device.
@@ -4919,7 +5023,7 @@ paths:
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemovePTZConfiguration:
     put:
       tags:
-      - PTZ - Configuration
+      - PTZ - PTZConfiguration
       summary: 'Media: RemovePTZConfiguration'
       description: |-
         Remove a PTZConfiguration on the device.
@@ -4962,7 +5066,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.RemovePTZConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AbsoluteMove:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZAbsoluteMove:
     put:
       tags:
       - PTZ - Actuation
@@ -4990,13 +5094,13 @@ paths:
           application/json:
             schema:
               properties:
-                AbsoluteMove:
+                PTZAbsoluteMove:
                   $ref: '#/components/schemas/ptz_AbsoluteMove'
               required:
-              - AbsoluteMove
+              - PTZAbsoluteMove
               type: object
             example:
-              AbsoluteMove:
+              PTZAbsoluteMove:
                 ProfileToken: PROFILE_3263078452
                 Position:
                   PanTilt:
@@ -5014,7 +5118,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.AbsoluteMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RelativeMove:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRelativeMove:
     put:
       tags:
       - PTZ - Actuation
@@ -5042,13 +5146,13 @@ paths:
           application/json:
             schema:
               properties:
-                RelativeMove:
+                PTZRelativeMove:
                   $ref: '#/components/schemas/ptz_RelativeMove'
               required:
-              - RelativeMove
+              - PTZRelativeMove
               type: object
             example:
-              RelativeMove:
+              PTZRelativeMove:
                 ProfileToken: PROFILE_3263078452
                 Translation:
                   PanTilt:
@@ -5066,7 +5170,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.RelativeMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/ContinuousMove:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZContinuousMove:
     put:
       tags:
       - PTZ - Actuation
@@ -5092,13 +5196,13 @@ paths:
           application/json:
             schema:
               properties:
-                ContinuousMove:
+                PTZContinuousMove:
                   $ref: '#/components/schemas/ptz_ContinuousMove'
               required:
-              - ContinuousMove
+              - PTZContinuousMove
               type: object
             example:
-              ContinuousMove:
+              PTZContinuousMove:
                 ProfileToken: profile_1
                 Velocity:
                   PanTilt:
@@ -5116,7 +5220,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.ContinuousMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Status:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStatus:
     get:
       tags:
       - PTZ - Actuation
@@ -5201,13 +5305,13 @@ paths:
                   id: c8ad64b4-db58-4c9b-9896-82fff02544c9
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Status
+                  sourceName: PTZStatus
                   origin: 1659659252963492000
                   readings:
                   - id: 71444c1c-9e85-4852-9c1e-9bd9eba8d616
                     origin: 1659659252963492000
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Status
+                    resourceName: PTZStatus
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -5230,7 +5334,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetStatus
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Stop:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStop:
     put:
       tags:
       - PTZ - Actuation
@@ -5256,13 +5360,13 @@ paths:
           application/json:
             schema:
               properties:
-                Stop:
+                PTZStop:
                   $ref: '#/components/schemas/ptz_Stop'
               required:
-              - Stop
+              - PTZStop
               type: object
             example:
-              Stop:
+              PTZStop:
                 ProfileToken: profile_1
                 PanTilt: true
       parameters:
@@ -5277,10 +5381,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.Stop
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Preset:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPreset:
     put:
       tags:
-      - PTZ - Preset
+      - PTZ - PTZPreset
       summary: 'PTZ: SetPreset'
       description: |-
         The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation.
@@ -5303,10 +5407,10 @@ paths:
           application/json:
             schema:
               properties:
-                Preset:
+                PTZPreset:
                   $ref: '#/components/schemas/ptz_SetPreset'
               required:
-              - Preset
+              - PTZPreset
               type: object
             example:
               SetPreset:
@@ -5324,10 +5428,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetPreset
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Presets:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPresets:
     get:
       tags:
-      - PTZ - Preset
+      - PTZ - PTZPreset
       summary: 'PTZ: GetPresets'
       description: |-
         Operation to request all PTZ presets for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode.
@@ -5409,13 +5513,13 @@ paths:
                   id: 79dde7e3-9730-4d33-aa9f-48e499b23207
                   deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
                   profileName: onvif-camera
-                  sourceName: Presets
+                  sourceName: PTZPresets
                   origin: 1659659260936957200
                   readings:
                   - id: 5816a933-ec39-4c58-b8cf-aa3fc8dcbd19
                     origin: 1659659260936957200
                     deviceName: TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4
-                    resourceName: Presets
+                    resourceName: PTZPresets
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -5453,10 +5557,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetPresets
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/GotoPreset:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZGotoPreset:
     put:
       tags:
-      - PTZ - Preset
+      - PTZ - PTZPreset
       summary: 'PTZ: GotoPreset'
       description: |-
         Operation to go to a saved preset position for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode.
@@ -5479,13 +5583,13 @@ paths:
           application/json:
             schema:
               properties:
-                GotoPreset:
+                PTZGotoPreset:
                   $ref: '#/components/schemas/ptz_GotoPreset'
               required:
-              - GotoPreset
+              - PTZGotoPreset
               type: object
             example:
-              GotoPreset:
+              PTZGotoPreset:
                 ProfileToken: PROFILE_3263078452
                 PresetToken: Preset1
       parameters:
@@ -5500,10 +5604,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GotoPreset
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemovePreset:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRemovePreset:
     put:
       tags:
-      - PTZ - Preset
+      - PTZ - PTZPreset
       summary: 'PTZ: RemovePreset'
       description: |-
         Operation to remove a PTZ preset for the Node in the selected profile. The operation is supported if the PresetPosition capability exists for teh Node in the selected profile.
@@ -5526,13 +5630,13 @@ paths:
           application/json:
             schema:
               properties:
-                RemovePreset:
+                PTZRemovePreset:
                   $ref: '#/components/schemas/ptz_RemovePreset'
               required:
-              - RemovePreset
+              - PTZRemovePreset
               type: object
             example:
-              RemovePreset:
+              PTZRemovePreset:
                 ProfileToken: profile_1
                 PresetToken: Preset1
       parameters:
@@ -5547,7 +5651,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.RemovePreset
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/GotoHomePosition:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZGotoHomePosition:
     put:
       tags:
       - PTZ - Home Position
@@ -5573,13 +5677,13 @@ paths:
           application/json:
             schema:
               properties:
-                GotoHomePosition:
+                PTZGotoHomePosition:
                   $ref: '#/components/schemas/ptz_GotoHomePosition'
               required:
-              - GotoHomePosition
+              - PTZGotoHomePosition
               type: object
             example:
-              GotoHomePosition:
+              PTZGotoHomePosition:
                 ProfileToken: profile_1
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
@@ -5593,13 +5697,13 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GotoHomePosition
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/HomePosition:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZHomePosition:
     put:
       tags:
       - PTZ - Home Position
       summary: 'PTZ: SetHomePosition'
       description: |-
-        Operation to save current position as the home position. The HomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the HomePosition is successful, it is possible to recall the Home Position with the GotoHomePosition command.
+        Operation to save current position as the home position. The PTZHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the PTZHomePosition is successful, it is possible to recall the Home Position with the PTZGotoHomePosition command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5619,13 +5723,13 @@ paths:
           application/json:
             schema:
               properties:
-                HomePosition:
+                PTZHomePosition:
                   $ref: '#/components/schemas/ptz_SetHomePosition'
               required:
-              - HomePosition
+              - PTZHomePosition
               type: object
             example:
-              HomePosition:
+              PTZHomePosition:
                 ProfileToken: profile_1
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
@@ -5639,7 +5743,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetHomePosition
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SendAuxiliaryCommand:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZSendAuxiliaryCommand:
     put:
       tags:
       - PTZ - Auxiliary
@@ -5679,13 +5783,13 @@ paths:
           application/json:
             schema:
               properties:
-                SendAuxiliaryCommand:
+                PTZSendAuxiliaryCommand:
                   $ref: '#/components/schemas/ptz_SendAuxiliaryCommand'
               required:
-              - SendAuxiliaryCommand
+              - PTZSendAuxiliaryCommand
               type: object
             example:
-              SendAuxiliaryCommand:
+              PTZSendAuxiliaryCommand:
                 ProfileToken: profile_1
                 AuxiliaryData: '123'
       parameters:
@@ -6108,7 +6212,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.GetProfiles
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsConfigurations:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AnalyticsConfigurations:
     get:
       tags:
       - Analytics - Profile Configuration
@@ -6163,19 +6267,19 @@ paths:
                   deviceName: >-
                     HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c
                   profileName: onvif-camera
-                  sourceName: AnalyticsConfigurations
+                  sourceName: Media2AnalyticsConfigurations
                   origin: 1664440527648299300
                   readings:
                   - id: 6e768a1a-a521-47c6-9d13-2337386768d1
                     origin: 1664440527648299300
                     deviceName: >-
                       HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c
-                    resourceName: AnalyticsConfigurations
+                    resourceName: Media2AnalyticsConfigurations
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
                     objectValue:
-                      Configurations:
+                      PTZConfigurations:
                       - AnalyticsEngineConfiguration:
                           AnalyticsModule:
                           - Name: MyCellMotionModule
@@ -6243,13 +6347,13 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.GetAnalyticsConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddConfiguration:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AddConfiguration:
     put:
       tags:
       - Analytics - Profile Configuration
       summary: 'Media2: AddConfiguration'
       description: |-
-        This operation adds one or more Configurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.
+        This operation adds one or more PTZConfigurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.
 
         Note that OSD elements must be added via the CreateOSD command.
 
@@ -6271,13 +6375,13 @@ paths:
           application/json:
             schema:
               properties:
-                AddConfiguration:
+                Media2AddConfiguration:
                   $ref: '#/components/schemas/media2_AddConfiguration'
               required:
-              - AddConfiguration
+              - Media2AddConfiguration
               type: object
             example:
-              AddConfiguration:
+              Media2AddConfiguration:
                 ProfileToken: PROFILE_3263078452
                 Configuration:
                 - Type: Analytics
@@ -6294,7 +6398,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.AddConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveConfiguration:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2RemoveConfiguration:
     put:
       tags:
       - Analytics - Profile Configuration
@@ -6320,13 +6424,13 @@ paths:
           application/json:
             schema:
               properties:
-                RemoveConfiguration:
+                Media2RemoveConfiguration:
                   $ref: '#/components/schemas/media2_RemoveConfiguration'
               required:
-              - RemoveConfiguration
+              - Media2RemoveConfiguration
               type: object
             example:
-              RemoveConfiguration:
+              Media2RemoveConfiguration:
                 ProfileToken: PROFILE_3263078452
                 Configuration:
                 - Type: Analytics
@@ -6749,7 +6853,7 @@ paths:
 
         Pass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.
 
-        Although this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and AnalyticsConfigurations.
+        Although this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and Media2AnalyticsConfigurations.
 
         The device shall ensure that a corresponding analytics engine starts operation when a client subscribes directly or indirectly for events produced by the analytics or rule engine or when a client requests the corresponding scene description stream. An analytics module must be attached to a Video source using the media profiles before it can be used. In case differing analytics configurations are attached to the same profile it is undefined which of the analytics module configuration becomes active if no stream is activated or multiple streams with different profiles are activated at the same time.
 
@@ -6959,7 +7063,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetAnalyticsModuleOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SupportedRules:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsSupportedRules:
     get:
       tags:
       - Analytics - Rules
@@ -7045,13 +7149,13 @@ paths:
                   id: 4694424b-74bb-45ee-a014-ebb6d09855f9
                   deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
                   profileName: onvif-camera
-                  sourceName: SupportedRules
+                  sourceName: AnalyticsSupportedRules
                   origin: 1665460098832568300
                   readings:
                   - id: 155dc49e-caa7-492c-be74-0cf150ca2302
                     origin: 1665460098832568300
                     deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
-                    resourceName: SupportedRules
+                    resourceName: AnalyticsSupportedRules
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -7216,7 +7320,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetSupportedRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Rules:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRules:
     get:
       tags:
       - Analytics - Rules
@@ -7301,13 +7405,13 @@ paths:
                   id: 16f84c82-ee09-41bb-a012-27b46cff27fe
                   deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
                   profileName: onvif-camera
-                  sourceName: Rules
+                  sourceName: AnalyticsRules
                   origin: 1665460089922944000
                   readings:
                   - id: 2f46e1f1-6f39-449a-bd68-6387db6a1008
                     origin: 1665460089922944000
                     deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
-                    resourceName: Rules
+                    resourceName: AnalyticsRules
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -7358,13 +7462,13 @@ paths:
           application/json:
             schema:
               properties:
-                Rules:
+                AnalyticsRules:
                   $ref: '#/components/schemas/analytics_ModifyRules'
               required:
-              - Rules
+              - AnalyticsRules
               type: object
             example:
-              Rules:
+              AnalyticsRules:
                 ConfigurationToken: VideoAnalyticsToken_3263078450
                 Rule:
                 - Name: MyMotionDetectorRule
@@ -7385,7 +7489,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.ModifyRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RuleOptions:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRuleOptions:
     get:
       tags:
       - Analytics - Rules
@@ -7473,13 +7577,13 @@ paths:
                   id: bf7a5fc7-7523-4690-87b7-273b2a373ed3
                   deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
                   profileName: onvif-camera
-                  sourceName: RuleOptions
+                  sourceName: AnalyticsRuleOptions
                   origin: 1665460126357157600
                   readings:
                   - id: 2bdd1ff4-7d2a-441b-bbc3-dfa50c27b096
                     origin: 1665460126357157600
                     deviceName: Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19
-                    resourceName: RuleOptions
+                    resourceName: AnalyticsRuleOptions
                     profileName: onvif-camera
                     valueType: Object
                     value: ''
@@ -7501,13 +7605,13 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetRuleOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CreateRules:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsCreateRules:
     put:
       tags:
       - Analytics - Rules
       summary: 'Analytics: CreateRules'
       description: |-
-        Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedRules, where the Name of the supported rule correspond to the type of an rule instance.
+        Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via AnalyticsSupportedRules, where the Name of the supported rule correspond to the type of an rule instance.
 
         Pass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.
 
@@ -7531,13 +7635,13 @@ paths:
           application/json:
             schema:
               properties:
-                CreateRules:
+                AnalyticsCreateRules:
                   $ref: '#/components/schemas/analytics_CreateRules'
               required:
-              - CreateRules
+              - AnalyticsCreateRules
               type: object
             example:
-              CreateRules:
+              AnalyticsCreateRules:
                 ConfigurationToken: VideoAnalyticsToken_3263078450
                 Rule:
                 - Name: Object Counting
@@ -7566,7 +7670,7 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.CreateRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DeleteRules:
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsDeleteRules:
     put:
       tags:
       - Analytics - Rules
@@ -7592,13 +7696,13 @@ paths:
           application/json:
             schema:
               properties:
-                DeleteRules:
+                AnalyticsDeleteRules:
                   $ref: '#/components/schemas/analytics_DeleteRules'
               required:
-              - DeleteRules
+              - AnalyticsDeleteRules
               type: object
             example:
-              DeleteRules:
+              AnalyticsDeleteRules:
                 ConfigurationToken: VideoAnalyticsToken_3263078450
                 RuleName:
                 - Object Counting
@@ -11961,6 +12065,13 @@ components:
               Capabilities element.
       required:
       - Capabilities
+      type: object
+    media_GetSnapshotUriResponse:
+      properties:
+        MediaUri:
+          $ref: '#/components/schemas/onvif_MediaUri'
+      required:
+      - MediaUri
       type: object
     media_GetStreamUriResponse:
       properties:

--- a/doc/openapi/v2/device-onvif-camera.yaml
+++ b/doc/openapi/v2/device-onvif-camera.yaml
@@ -699,22 +699,6 @@ paths:
       tags:
       - Auto Discovery
       summary: 'Device: GetDiscoveryMode'
-      description: |-
-        This operation gets the discovery mode of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support retrieval of the discovery mode setting through the GetDiscoveryMode command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -768,12 +752,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetDiscoveryMode
-    put:
-      tags:
-      - Auto Discovery
-      summary: 'Device: SetDiscoveryMode'
       description: |-
-        This operation sets the discovery mode operation of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support configuration of the discovery mode setting through the SetDiscoveryMode command.
+        This operation gets the discovery mode of a device. See Section 7.2 for the definition of the
+        				different device discovery modes. The device shall support retrieval of the discovery mode
+        				setting through the GetDiscoveryMode command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -788,6 +770,10 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Auto Discovery
+      summary: 'Device: SetDiscoveryMode'
       requestBody:
         content:
           application/json:
@@ -824,13 +810,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetDiscoveryMode
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddDiscoveryScopes:
-    put:
-      tags:
-      - Auto Discovery
-      summary: 'Device: AddScopes'
       description: |-
-        This operation adds new configurable scope parameters to a device. The scope parameters are used in the device discovery to match a probe message. The device shall support addition of discovery scope parameters through the AddScopes command.
+        This operation sets the discovery mode operation of a device. See Section 7.2 for the
+        				definition of the different device discovery modes. The device shall support configuration of
+        				the discovery mode setting through the SetDiscoveryMode command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -840,11 +823,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddDiscoveryScopes:
+    put:
+      tags:
+      - Auto Discovery
+      summary: 'Device: AddScopes'
       requestBody:
         content:
           application/json:
@@ -871,16 +859,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.AddScopes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DiscoveryScopes:
-    get:
-      tags:
-      - Auto Discovery
-      summary: 'Device: GetScopes'
       description: |-
-        This operation requests the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The Scope parameters are of two different types:  
-        \- Fixed  
-        \- Configurable  
-        Fixed scope parameters are permanent device characteristics and cannot be removed through the device management interface. The scope type is indicated in the scope list returned in the get scope parameters response. A device shall support retrieval of discovery scope parameters through the GetScopes command. As some scope parameters are mandatory, the device shall return a non-empty scope list in the response.
+        This operation adds new configurable scope parameters to a device. The scope parameters
+        				are used in the device discovery to match a probe message. The device shall
+        				support addition of discovery scope parameters through the AddScopes command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -890,11 +872,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DiscoveryScopes:
+    get:
+      tags:
+      - Auto Discovery
+      summary: 'Device: GetScopes'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -958,12 +945,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetScopes
-    put:
-      tags:
-      - Auto Discovery
-      summary: 'Device: SetScopes'
       description: |-
-        This operation sets the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message. This operation replaces all existing configurable scope parameters (not fixed parameters). If this shall be avoided, one should use the scope add command instead.
+        This operation requests the scope parameters of a device. The scope parameters are used in
+        				the device discovery to match a probe message, see Section 7. The Scope parameters are of
+        				two different types:
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -976,8 +961,12 @@ paths:
         | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Auto Discovery
+      summary: 'Device: SetScopes'
       requestBody:
         content:
           application/json:
@@ -1004,13 +993,12 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetScopes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveDiscoveryScopes:
-    put:
-      tags:
-      - Auto Discovery
-      summary: 'Device: RemoveScopes'
       description: |-
-        This operation deletes scope-configurable scope parameters from a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The device shall support deletion of discovery scope parameters through the RemoveScopes command
+        This operation sets the scope parameters of a device. The scope parameters are used in the
+        				device discovery to match a probe message.
+        				This operation replaces all existing configurable scope parameters (not fixed parameters). If
+        				this shall be avoided, one should use the scope add command instead. The device shall
+        				support configuration of discovery scope parameters through the SetScopes command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1020,11 +1008,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveDiscoveryScopes:
+    put:
+      tags:
+      - Auto Discovery
+      summary: 'Device: RemoveScopes'
       requestBody:
         content:
           application/json:
@@ -1076,6 +1069,26 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.RemoveScopes
+      description: |-
+        This operation deletes scope-configurable scope parameters from a device. The scope
+        				parameters are used in the device discovery to match a probe message, see Section 7. The
+        				device shall support deletion of discovery scope parameters through the RemoveScopes
+        				command.
+        				Table
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/EndpointReference:
     get:
       tags:
@@ -1129,22 +1142,6 @@ paths:
       tags:
       - Network Configuration
       summary: 'Device: GetHostname'
-      description: |-
-        This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -1200,13 +1197,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetHostname
-    put:
-      tags:
-      - Network Configuration
-      summary: 'Device: SetHostname'
       description: |-
-        This operation sets the hostname on a device. It shall be possible to set the device hostname configurations through the SetHostname command.  
-        A device shall accept string formatted according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings.
+        This operation is used by an endpoint to get the hostname from a device. The device shall
+        				return its hostname configurations through the GetHostname command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1216,11 +1209,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Network Configuration
+      summary: 'Device: SetHostname'
       requestBody:
         content:
           application/json:
@@ -1246,13 +1243,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetHostname
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DNS:
-    get:
-      tags:
-      - Network Configuration
-      summary: 'Device: GetDNS'
       description: |-
-        This operation gets the DNS settings from a device. The device shall return its DNS configurations through the GetDNS command.
+        This operation sets the hostname on a device. It shall be possible to set the device hostname
+        				configurations through the SetHostname command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1267,6 +1260,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DNS:
+    get:
+      tags:
+      - Network Configuration
+      summary: 'Device: GetDNS'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -1326,12 +1324,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetDNS
-    put:
-      tags:
-      - Network Configuration
-      summary: 'Device: SetDNS'
       description: |-
-        This operation sets the DNS settings on a device. It shall be possible to set the device DNS configurations through the SetDNS command.
+        This operation gets the DNS settings from a device. The device shall return its DNS
+        				configurations through the GetDNS command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1346,6 +1341,10 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Network Configuration
+      summary: 'Device: SetDNS'
       requestBody:
         content:
           application/json:
@@ -1374,13 +1373,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetDNS
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkInterfaces:
-    get:
-      tags:
-      - Network Configuration
-      summary: 'Device: GetNetworkInterfaces'
       description: |-
-        This operation gets the network interface configuration from a device. The device shall support return of network interface configuration settings as defined by the NetworkInterface type through the GetNetworkInterfaces command.
+        This operation sets the DNS settings on a device. It shall be possible to set the device DNS
+        				configurations through the SetDNS command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1390,11 +1385,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkInterfaces:
+    get:
+      tags:
+      - Network Configuration
+      summary: 'Device: GetNetworkInterfaces'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -1461,14 +1461,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetNetworkInterfaces
-    put:
-      tags:
-      - Network Configuration
-      summary: 'Device: SetNetworkInterfaces'
       description: |-
-        This operation sets the network interface configuration on a device. The device shall support network configuration of supported network interfaces through the SetNetworkInterfaces command.
-
-        For interoperability with a client unaware of the IEEE 802.11 extension a device shall retain its IEEE 802.11 configuration if the IEEE 802.11 configuration element isn’t present in the request.
+        This operation gets the network interface configuration from a device. The device shall
+        				support return of network interface configuration settings as defined by the NetworkInterface
+        				type through the GetNetworkInterfaces command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1478,11 +1474,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Network Configuration
+      summary: 'Device: SetNetworkInterfaces'
       requestBody:
         content:
           application/json:
@@ -1512,13 +1512,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetNetworkInterfaces
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkProtocols:
-    get:
-      tags:
-      - Network Configuration
-      summary: 'Device: GetNetworkProtocols'
       description: |-
-        This operation gets defined network protocols from a device. The device shall support the GetNetworkProtocols command returning configured network protocols.
+        This operation sets the network interface configuration on a device. The device shall support
+        				network configuration of supported network interfaces through the SetNetworkInterfaces
+        				command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1528,11 +1525,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkProtocols:
+    get:
+      tags:
+      - Network Configuration
+      summary: 'Device: GetNetworkProtocols'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -1592,12 +1594,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetNetworkProtocols
-    put:
-      tags:
-      - Network Configuration
-      summary: 'Device: SetNetworkProtocols'
       description: |-
-        This operation configures defined network protocols on a device. The device shall support configuration of defined network protocols through the SetNetworkProtocols command.
+        This operation gets defined network protocols from a device. The device shall support the
+        				GetNetworkProtocols command returning configured network protocols.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1607,11 +1606,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Network Configuration
+      summary: 'Device: SetNetworkProtocols'
       requestBody:
         content:
           application/json:
@@ -1646,13 +1649,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetNetworkProtocols
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkDefaultGateway:
-    get:
-      tags:
-      - Network Configuration
-      summary: 'Device: GetNetworkDefaultGateway'
       description: |-
-        This operation gets the default gateway settings from a device. The device shall support the GetNetworkDefaultGateway command returning configured default gateway address(es).
+        This operation configures defined network protocols on a device. The device shall support
+        				configuration of defined network protocols through the SetNetworkProtocols command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1667,6 +1666,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkDefaultGateway:
+    get:
+      tags:
+      - Network Configuration
+      summary: 'Device: GetNetworkDefaultGateway'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -1724,12 +1728,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetNetworkDefaultGateway
-    put:
-      tags:
-      - Network Configuration
-      summary: 'Device: SetNetworkDefaultGateway'
       description: |-
-        This operation sets the default gateway settings on a device. The device shall support configuration of default gateway through the SetNetworkDefaultGateway command.
+        This operation gets the default gateway settings from a device. The device shall support the
+        				GetNetworkDefaultGateway command returning configured default gateway address(es).
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -1744,6 +1745,10 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Network Configuration
+      summary: 'Device: SetNetworkDefaultGateway'
       requestBody:
         content:
           application/json:
@@ -1769,6 +1774,23 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetNetworkDefaultGateway
+      description: |-
+        This operation sets the default gateway settings on a device. The device shall support
+        				configuration of default gateway through the SetNetworkDefaultGateway command.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/NetworkConfiguration:
     get:
       tags:
@@ -1873,7 +1895,7 @@ paths:
     put:
       tags:
       - Network Configuration
-      summary: SetNetworkConfiguration
+      summary: NetworkConfiguration
       description: >-
         Used to configure network resources for a device such as Hostname, DNS,
         NetworkInterfaces, NetworkProtocols and NetworkDefaultGateway.
@@ -1927,22 +1949,6 @@ paths:
       tags:
       - System Function
       summary: 'Device: GetDeviceInformation'
-      description: |-
-        This operation gets basic device information from the device.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -2000,15 +2006,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetDeviceInformation
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SystemDateAndTime:
-    get:
-      tags:
-      - System Function
-      summary: 'Device: GetSystemDateAndTime'
       description: |-
-        This operation gets the device system date and time. The device shall support the return of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the GetSystemDateAndTime command.
-
-        A device shall provide the UTCDateTime information.
+        This operation gets basic device information from the device.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2023,6 +2022,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SystemDateAndTime:
+    get:
+      tags:
+      - System Function
+      summary: 'Device: GetSystemDateAndTime'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -2100,18 +2104,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetSystemDateAndTime
-    put:
-      tags:
-      - System Function
-      summary: 'Device: SetSystemDateAndTime'
       description: |-
-        This operation sets the device system date and time. The device shall support the configuration of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the SetSystemDateAndTime command.
-
-        If system time and date are set manually, the client shall include UTCDateTime in the request.
-
-        A TimeZone token which is not formed according to the rules of IEEE 1003.1 section 8.3 is considered as invalid timezone.
-
-        The DayLightSavings flag should be set to true to activate any DST settings of the TimeZone string. Clear the DayLightSavings flag if the DST portion of the TimeZone settings should be ignored.
+        This operation gets the device system date and time. The device shall support the return of
+        				the daylight saving setting and of the manual system date and time (if applicable) or indication
+        				of NTP time (if applicable) through the GetSystemDateAndTime command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2121,11 +2117,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ | Tapo does not support setting the `DaylightSavings` field to `false`. Regardless of the setting, the camera will always use daylight savings time. |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - System Function
+      summary: 'Device: SetSystemDateAndTime'
       requestBody:
         content:
           application/json:
@@ -2161,13 +2161,11 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetSystemDateAndTime
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SystemFactoryDefault:
-    put:
-      tags:
-      - System Function
-      summary: 'Device: SetSystemFactoryDefault'
       description: |-
-        This operation reloads the parameters on the device to their factory default values.
+        This operation sets the device system date and time. The device shall support the
+        				configuration of the daylight saving setting and of the manual system date and time (if
+        				applicable) or indication of NTP time (if applicable) through the SetSystemDateAndTime
+        				command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2177,11 +2175,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ✔️ | Tapo does not support setting the `DaylightSavings` field to `false`. Regardless of the setting, the camera will always use daylight savings time. |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SystemFactoryDefault:
+    put:
+      tags:
+      - System Function
+      summary: 'Device: SetSystemFactoryDefault'
       requestBody:
         content:
           application/json:
@@ -2207,6 +2210,22 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetSystemFactoryDefault
+      description: |-
+        This operation reloads the parameters on the device to their factory default values.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ✔️ |  |
+        | **Tapo C200** | ✔️ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/RebootNeeded:
     get:
       tags:
@@ -2304,22 +2323,6 @@ paths:
       tags:
       - User Handling
       summary: 'Device: GetUsers'
-      description: |-
-        This operation lists the registered users and corresponding credentials on a device. The device shall support retrieval of registered device users and their credentials for the user token through the GetUsers command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ | Tapo returns `200 OK` for all User Management commands, but none of them actually do anything. The only way to modify the users is through the Tapo app. |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -2377,14 +2380,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.GetUsers
-    put:
-      tags:
-      - User Handling
-      summary: 'Device: SetUser'
       description: |-
-        This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user.
-
-        ONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper.
+        This operation lists the registered users and corresponding credentials on a device. The
+        				device shall support retrieval of registered device users and their credentials for the user
+        				token through the GetUsers command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2399,6 +2398,10 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - User Handling
+      summary: 'Device: SetUser'
       requestBody:
         content:
           application/json:
@@ -2430,15 +2433,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.SetUser
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CreateUsers:
-    put:
-      tags:
-      - User Handling
-      summary: 'Device: CreateUsers'
       description: |-
-        This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user.
-
-        ONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper.
+        This operation updates the settings for one or several users on a device for authentication purposes.
+        				The device shall support update of device users and their credentials through the SetUser command. 
+        				Either all change requests are processed successfully or a fault message shall be returned and no change requests be processed.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2453,6 +2451,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CreateUsers:
+    put:
+      tags:
+      - User Handling
+      summary: 'Device: CreateUsers'
       requestBody:
         content:
           application/json:
@@ -2484,13 +2487,11 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.CreateUsers
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DeleteUsers:
-    put:
-      tags:
-      - User Handling
-      summary: 'Device: DeleteUsers'
       description: |-
-        This operation deletes users on a device. The device shall support deletion of device users and their credentials through the DeleteUsers command. A device may have one or more fixed users that cannot be deleted to ensure access to the unit. Either all users are deleted successfully or a fault message shall be returned and no users be deleted.
+        This operation creates new device users and corresponding credentials on a device for authentication purposes. 
+        				The device shall support creation of device users and their credentials through the CreateUsers
+        				command. Either all users are created successfully or a fault message shall be returned
+        				without creating any user.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2505,6 +2506,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DeleteUsers:
+    put:
+      tags:
+      - User Handling
+      summary: 'Device: DeleteUsers'
       requestBody:
         content:
           application/json:
@@ -2532,13 +2538,11 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl#op.DeleteUsers
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfigurations:
-    get:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: GetMetadataConfigurations'
       description: |-
-        This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command.
+        This operation deletes users on a device. The device shall support deletion of device users and their credentials 
+        				through the DeleteUsers command. A device may have one or more fixed users
+        				that cannot be deleted to ensure access to the unit. Either all users are deleted successfully or a
+        				fault message shall be returned and no users be deleted.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2548,11 +2552,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ❌ | Tapo returns `200 OK` for all User Management commands, but none of them actually do anything. The only way to modify the users is through the Tapo app. |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfigurations:
+    get:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: GetMetadataConfigurations'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -2623,13 +2632,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetMetadataConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfiguration:
-    get:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: GetMetadataConfiguration'
       description: |-
-        The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known.
+        This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2644,6 +2648,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfiguration:
+    get:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: GetMetadataConfiguration'
       parameters:
       - name: jsonObject
         in: query
@@ -2746,12 +2755,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetMetadataConfiguration
-    put:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: SetMetadataConfiguration'
       description: |-
-        This operation modifies a metadata configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be updated immediately according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification.
+        The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2766,6 +2771,10 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: SetMetadataConfiguration'
       requestBody:
         content:
           application/json:
@@ -2794,13 +2803,13 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.SetMetadataConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CompatibleMetadataConfigurations:
-    get:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: GetCompatibleMetadataConfigurations'
       description: |-
-        This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
+        This operation modifies a metadata configuration. The ForcePersistence flag indicates if the
+        changes shall remain after reboot of the device. Changes in the Multicast settings shall
+        always be persistent. Running streams using this configuration may be updated immediately
+        according to the new settings. The changes are not guaranteed to take effect unless the client
+        requests a new stream URI and restarts any affected streams. NVC methods for changing a
+        running stream are out of scope for this specification.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2815,6 +2824,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CompatibleMetadataConfigurations:
+    get:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: GetCompatibleMetadataConfigurations'
       parameters:
       - name: jsonObject
         in: query
@@ -2917,13 +2931,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetCompatibleMetadataConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfigurationOptions:
-    get:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: GetMetadataConfigurationOptions'
       description: |-
-        This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration.
+        This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -2938,6 +2947,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MetadataConfigurationOptions:
+    get:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: GetMetadataConfigurationOptions'
       parameters:
       - name: jsonObject
         in: query
@@ -3032,13 +3046,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetMetadataConfigurationOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddMetadataConfiguration:
-    put:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: AddMetadataConfiguration'
       description: |-
-        This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data.
+        This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -3053,6 +3062,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddMetadataConfiguration:
+    put:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: AddMetadataConfiguration'
       requestBody:
         content:
           application/json:
@@ -3079,13 +3093,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.AddMetadataConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveMetadataConfiguration:
-    put:
-      tags:
-      - Metadata Configuration
-      summary: 'Media: RemoveMetadataConfiguration'
       description: |-
-        This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent.
+        This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -3100,6 +3109,11 @@ paths:
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemoveMetadataConfiguration:
+    put:
+      tags:
+      - Metadata Configuration
+      summary: 'Media: RemoveMetadataConfiguration'
       requestBody:
         content:
           application/json:
@@ -3125,13 +3139,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.RemoveMetadataConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MediaProfiles:
-    get:
-      tags:
-      - Video Streaming
-      summary: 'Media: GetProfiles'
       description: |-
-        Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command.
+        This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -3141,11 +3150,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/MediaProfiles:
+    get:
+      tags:
+      - Video Streaming
+      summary: 'Media: GetProfiles'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -3431,6 +3445,25 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetProfiles
+      description: |-
+        Any endpoint can ask for the existing media profiles of a device using the GetProfiles
+        command. Pre-configured or dynamically configured profiles can be retrieved using this
+        command. This command lists all configured profiles in a device. The client does not need to
+        know the media profile in order to use the command.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ✔️ |  |
+        | **Tapo C200** | ✔️ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ✔️ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/StreamUri:
     get:
       tags:
@@ -3778,17 +3811,6 @@ paths:
       tags:
       - Video Encoder Configuration
       summary: 'Media: GetVideoEncoderConfigurations'
-      description: |-
-        This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -3865,13 +3887,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetVideoEncoderConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/VideoEncoderConfiguration:
-    get:
-      tags:
-      - Video Encoder Configuration
-      summary: 'Media: GetVideoEncoderConfiguration'
       description: |-
-        If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command.
+        This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -3880,12 +3897,12 @@ paths:
 
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ✔️ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/VideoEncoderConfiguration:
+    get:
+      tags:
+      - Video Encoder Configuration
+      summary: 'Media: GetVideoEncoderConfiguration'
       parameters:
       - name: jsonObject
         in: query
@@ -3993,14 +4010,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetVideoEncoderConfiguration
-    put:
-      tags:
-      - Video Encoder Configuration
-      summary: 'Media: SetVideoEncoderConfiguration'
       description: |-
-        This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.
-
-        SessionTimeout is provided as a hint for keeping rtsp session by a device. If necessary the device may adapt parameter values for SessionTimeout elements without returning an error. For the time between keep alive calls the client shall adhere to the timeout value signaled via RTSP.
+        If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4010,11 +4021,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - Video Encoder Configuration
+      summary: 'Media: SetVideoEncoderConfiguration'
       requestBody:
         content:
           application/json:
@@ -4079,17 +4094,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.SetVideoEncoderConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/VideoEncoderConfigurationOptions:
-    get:
-      tags:
-      - Video Encoder Configuration
-      summary: 'Media: GetVideoEncoderConfigurationOptions'
       description: |-
-        This operation returns the available options (supported values and ranges for video encoder configuration parameters) when the video encoder parameters are reconfigured.
-
-        For JPEG, MPEG4 and H264 extension elements have been defined that provide additional information. A device must provide the XxxOption information for all encodings supported and should additionally provide the corresponding XxxOption2 information.
-
-        This response contains the available video encoder configuration options. If a video encoder configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile. If no tokens are specified, the options shall be considered generic for the device.
+        This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4099,11 +4105,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ✔️ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/VideoEncoderConfigurationOptions:
+    get:
+      tags:
+      - Video Encoder Configuration
+      summary: 'Media: GetVideoEncoderConfigurationOptions'
       parameters:
       - name: jsonObject
         in: query
@@ -4237,15 +4248,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetVideoEncoderConfigurationOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNodes:
-    get:
-      tags:
-      - PTZ - Capabilities
-      summary: 'PTZ: GetNodes'
       description: |-
-        Get the descriptions of the available PTZ Nodes.
-
-        A PTZ-capable device may have multiple PTZ Nodes. The PTZ Nodes may represent mechanical PTZ drivers, uploaded PTZ drivers or digital PTZ drivers. PTZ Nodes are the lowest level entities in the PTZ control API and reflect the supported PTZ capabilities. The PTZ Node is referenced either by its name or by its reference token.
+        This operation returns the available options (supported values and ranges for video encoder 
+        				configuration parameters) when the video encoder parameters are reconfigured.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4254,12 +4259,17 @@ paths:
 
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ❌ |  |
+        | **Hikvision DFI6256TE** | ✔️ |  |
         | **Tapo C200** | ✔️ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
-        | **GeoVision GV-BX8700** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ✔️ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNodes:
+    get:
+      tags:
+      - PTZ - Capabilities
+      summary: 'PTZ: GetNodes'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -4371,13 +4381,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetNodes
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNode:
-    get:
-      tags:
-      - PTZ - Capabilities
-      summary: 'PTZ: GetNode'
       description: |-
-        Get a specific PTZ Node identified by a reference token or a name.
+        Get the descriptions of the available PTZ Nodes.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4392,6 +4397,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZNode:
+    get:
+      tags:
+      - PTZ - Capabilities
+      summary: 'PTZ: GetNode'
       parameters:
       - name: jsonObject
         in: query
@@ -4534,15 +4544,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetNode
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurations:
-    get:
-      tags:
-      - PTZ - Configuration
-      summary: 'PTZ: GetConfigurations'
       description: |-
-        Get all the existing PTZConfigurations from the device.  
-        The default Position/Translation/Velocity Spaces are introduced to allow NVCs sending move requests without the need to specify a certain coordinate system. The default Speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.  
-        The allowed pan and tilt range for Pan/Tilt Limits is defined by a two-dimensional space range that is mapped to a specific Absolute Pan/Tilt Position Space. At least one Pan/Tilt Position Space is required by the PTZNode to support Pan/Tilt limits. The limits apply to all supported absolute, relative and continuous Pan/Tilt movements. The limits shall be checked within the coordinate system for which the limits have been specified. That means that even if movements are specified in a different coordinate system, the requested movements shall be transformed to the coordinate system of the limits where the limits can be checked. When a relative or continuous movements is specified, which would leave the specified limits, the PTZ unit has to move along the specified limits. The Zoom Limits have to be interpreted accordingly.
+        Get a specific PTZ Node identified by a reference
+                token or a name.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4557,6 +4561,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurations:
+    get:
+      tags:
+      - PTZ - Configuration
+      summary: 'PTZ: GetConfigurations'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -4628,17 +4637,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfiguration:
-    get:
-      tags:
-      - PTZ - Configuration
-      summary: 'PTZ: GetConfiguration'
       description: |-
-        Get a specific PTZconfiguration from the device, identified by its reference token or name.
-
-        The default Position/Translation/Velocity Spaces are introduced to allow NVCs sending move requests without the need to specify a certain coordinate system. The default Speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.
-
-        The allowed pan and tilt range for Pan/Tilt Limits is defined by a two-dimensional space range that is mapped to a specific Absolute Pan/Tilt Position Space. At least one Pan/Tilt Position Space is required by the PTZNode to support Pan/Tilt limits. The limits apply to all supported absolute, relative and continuous Pan/Tilt movements. The limits shall be checked within the coordinate system for which the limits have been specified. That means that even if movements are specified in a different coordinate system, the requested movements shall be transformed to the coordinate system of the limits where the limits can be checked. When a relative or continuous movements is specified, which would leave the specified limits, the PTZ unit has to move along the specified limits. The Zoom Limits have to be interpreted accordingly.
+        Get all the existing PTZConfigurations from the device.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4653,6 +4653,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfiguration:
+    get:
+      tags:
+      - PTZ - Configuration
+      summary: 'PTZ: GetConfiguration'
       parameters:
       - name: jsonObject
         in: query
@@ -4755,12 +4760,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfiguration
-    put:
-      tags:
-      - PTZ - Configuration
-      summary: 'PTZ: SetConfiguration'
       description: |-
-        Set/update a existing PTZConfiguration on the device.
+        Get a specific PTZconfiguration from the device, identified by its reference token or name.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4770,11 +4771,15 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+    put:
+      tags:
+      - PTZ - Configuration
+      summary: 'PTZ: SetConfiguration'
       requestBody:
         content:
           application/json:
@@ -4810,13 +4815,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurationOptions:
-    get:
-      tags:
-      - PTZ - Configuration
-      summary: 'PTZ: GetConfigurationOptions'
       description: |-
-        List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node.
+        Set/update a existing PTZConfiguration on the device.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4826,11 +4826,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZConfigurationOptions:
+    get:
+      tags:
+      - PTZ - Configuration
+      summary: 'PTZ: GetConfigurationOptions'
       parameters:
       - name: jsonObject
         in: query
@@ -4973,13 +4978,13 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetConfigurationOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddPTZConfiguration:
-    put:
-      tags:
-      - PTZ - Configuration
-      summary: 'Media: AddPTZConfiguration'
       description: |-
-        Add a new PTZConfiguration on the device.
+        List supported coordinate systems including their range limitations. Therefore, the options
+        				MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a
+        				Video Source Configuration. In that case, the options may additionally contain coordinate
+        				systems referring to the image coordinate system described by the Video Source
+        				Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within
+        				which Timeouts are accepted by the PTZ Node.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -4989,11 +4994,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AddPTZConfiguration:
+    put:
+      tags:
+      - PTZ - Configuration
+      summary: 'Media: AddPTZConfiguration'
       requestBody:
         content:
           application/json:
@@ -5020,13 +5030,11 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.AddPTZConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemovePTZConfiguration:
-    put:
-      tags:
-      - PTZ - Configuration
-      summary: 'Media: RemovePTZConfiguration'
       description: |-
-        Remove a PTZConfiguration on the device.
+        This operation adds a PTZConfiguration to an existing media profile. If a configuration exists
+        in the media profile, it will be replaced. The change shall be persistent. Adding a PTZConfiguration to a media profile means that streams using that media profile can
+        contain PTZ status (in the metadata), and that the media profile can be used for controlling
+        PTZ movement.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5041,6 +5049,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/RemovePTZConfiguration:
+    put:
+      tags:
+      - PTZ - Configuration
+      summary: 'Media: RemovePTZConfiguration'
       requestBody:
         content:
           application/json:
@@ -5066,15 +5079,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.RemovePTZConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZAbsoluteMove:
-    put:
-      tags:
-      - PTZ - Actuation
-      summary: 'PTZ: AbsoluteMove'
       description: |-
-        Operation to move pan,tilt or zoom to a absolute destination.
-
-        The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
+        This operation removes a PTZConfiguration from an existing media profile. If the media profile
+        does not contain a PTZConfiguration, the operation has no effect. The removal shall be persistent.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5084,11 +5091,16 @@ paths:
         | Camera | Supported? &nbsp;&nbsp; | Notes |
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ✔️ |  |
+        | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZAbsoluteMove:
+    put:
+      tags:
+      - PTZ - Actuation
+      summary: 'PTZ: AbsoluteMove'
       requestBody:
         content:
           application/json:
@@ -5118,15 +5130,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.AbsoluteMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRelativeMove:
-    put:
-      tags:
-      - PTZ - Actuation
-      summary: 'PTZ: RelativeMove'
       description: |-
-        Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space.
-
-        The speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
+        Operation to move pan,tilt or zoom to a absolute destination.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5141,6 +5146,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRelativeMove:
+    put:
+      tags:
+      - PTZ - Actuation
+      summary: 'PTZ: RelativeMove'
       requestBody:
         content:
           application/json:
@@ -5170,13 +5180,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.RelativeMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZContinuousMove:
-    put:
-      tags:
-      - PTZ - Actuation
-      summary: 'PTZ: ContinuousMove'
       description: |-
-        Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used.
+        Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5191,6 +5196,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZContinuousMove:
+    put:
+      tags:
+      - PTZ - Actuation
+      summary: 'PTZ: ContinuousMove'
       requestBody:
         content:
           application/json:
@@ -5220,13 +5230,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.ContinuousMove
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStatus:
-    get:
-      tags:
-      - PTZ - Actuation
-      summary: 'PTZ: GetStatus'
       description: |-
-        Operation to request PTZ status for the Node in the selected profile.
+        Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5241,6 +5246,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStatus:
+    get:
+      tags:
+      - PTZ - Actuation
+      summary: 'PTZ: GetStatus'
       parameters:
       - name: jsonObject
         in: query
@@ -5334,13 +5344,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetStatus
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStop:
-    put:
-      tags:
-      - PTZ - Actuation
-      summary: 'PTZ: Stop'
       description: |-
-        Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type. If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
+        Operation to request PTZ status for the Node in the
+        				selected profile.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5355,6 +5361,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZStop:
+    put:
+      tags:
+      - PTZ - Actuation
+      summary: 'PTZ: Stop'
       requestBody:
         content:
           application/json:
@@ -5381,13 +5392,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.Stop
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPreset:
-    put:
-      tags:
-      - PTZ - PTZPreset
-      summary: 'PTZ: SetPreset'
       description: |-
-        The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation.
+        Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type.
+        If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5402,6 +5409,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPreset:
+    put:
+      tags:
+      - PTZ - PTZPreset
+      summary: 'PTZ: SetPreset'
       requestBody:
         content:
           application/json:
@@ -5428,13 +5440,16 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetPreset
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPresets:
-    get:
-      tags:
-      - PTZ - PTZPreset
-      summary: 'PTZ: GetPresets'
       description: |-
-        Operation to request all PTZ presets for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode.
+        The SetPreset command saves the current device position parameters so that the device can
+        				move to the saved preset position through the GotoPreset operation.
+        				In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is
+        				successful, the Response contains the PresetToken which uniquely identifies the Preset. An
+        				existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset.
+        				In both cases (overwriting or creation) an optional PresetName can be specified. The
+        				operation fails if the PTZ device is moving during the SetPreset operation.
+        				The device MAY internally save additional states such as imaging properties in the PTZ
+        				Preset which then should be recalled in the GotoPreset operation.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5449,6 +5464,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZPresets:
+    get:
+      tags:
+      - PTZ - PTZPreset
+      summary: 'PTZ: GetPresets'
       parameters:
       - name: jsonObject
         in: query
@@ -5557,13 +5577,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GetPresets
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZGotoPreset:
-    put:
-      tags:
-      - PTZ - PTZPreset
-      summary: 'PTZ: GotoPreset'
       description: |-
-        Operation to go to a saved preset position for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode.
+        Operation to request all PTZ presets for the PTZNode
+                in the selected profile. The operation is supported if there is support
+                for at least on PTZ preset by the PTZNode.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5578,6 +5595,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZGotoPreset:
+    put:
+      tags:
+      - PTZ - PTZPreset
+      summary: 'PTZ: GotoPreset'
       requestBody:
         content:
           application/json:
@@ -5604,13 +5626,10 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.GotoPreset
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRemovePreset:
-    put:
-      tags:
-      - PTZ - PTZPreset
-      summary: 'PTZ: RemovePreset'
       description: |-
-        Operation to remove a PTZ preset for the Node in the selected profile. The operation is supported if the PresetPosition capability exists for teh Node in the selected profile.
+        Operation to go to a saved preset position for the
+                PTZNode in the selected profile. The operation is supported if there is
+                support for at least on PTZ preset by the PTZNode.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -5625,6 +5644,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZRemovePreset:
+    put:
+      tags:
+      - PTZ - PTZPreset
+      summary: 'PTZ: RemovePreset'
       requestBody:
         content:
           application/json:
@@ -5651,6 +5675,27 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.RemovePreset
+      description: |-
+        Operation to remove a PTZ preset for the Node in
+                the
+                selected profile. The operation is supported if the
+                PresetPosition
+                capability exists for teh Node in the
+                selected profile.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ❌ |  |
+        | **Tapo C200** | ✔️ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
+        | **GeoVision GV-BX8700** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZGotoHomePosition:
     put:
       tags:
@@ -5702,22 +5747,6 @@ paths:
       tags:
       - PTZ - Home Position
       summary: 'PTZ: SetHomePosition'
-      description: |-
-        Operation to save current position as the home position. The PTZHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the PTZHomePosition is successful, it is possible to recall the Home Position with the PTZGotoHomePosition command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ❌ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
-        | **GeoVision GV-BX8700** | ❌ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       requestBody:
         content:
           application/json:
@@ -5743,6 +5772,25 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/ptz/wsdl/ptz.wsdl#op.SetHomePosition
+      description: |-
+        Operation to save current position as the home position.
+        				The SetHomePosition command returns with a failure if the “home” position is fixed and
+        				cannot be overwritten. If the SetHomePosition is successful, it is possible to recall the
+        				Home Position with the GotoHomePosition command.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ❌ |  |
+        | **Tapo C200** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
+        | **GeoVision GV-BX8700** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/PTZSendAuxiliaryCommand:
     put:
       tags:
@@ -5809,18 +5857,6 @@ paths:
       tags:
       - Event Handling
       summary: 'Event: GetEventProperties'
-      description: |-
-        The WS-BaseNotification specification defines a set of OPTIONAL WS-ResouceProperties. This specification does not require the implementation of the WS-ResourceProperty interface. Instead, the subsequent direct interface shall be implemented by an ONVIF compliant device in order to provide information about the FilterDialects, Schema files and topics supported by the device.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Tapo C200** | ✔️ |  |
-        </details>
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -5987,6 +6023,22 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver10/events/wsdl/event.wsdl#op.GetEventProperties
+      description: |-
+        The WS-BaseNotification specification defines a set of OPTIONAL WS-ResouceProperties.
+        				This specification does not require the implementation of the WS-ResourceProperty interface.
+        				Instead, the subsequent direct interface shall be implemented by an ONVIF compliant device
+        				in order to provide information about the FilterDialects, Schema files and topics supported by
+        				the device.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Tapo C200** | ✔️ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/BaseNotificationSubscription:
     put:
       tags:
@@ -6107,22 +6159,6 @@ paths:
       tags:
       - Analytics - Profile Configuration
       summary: 'Media2: GetProfiles'
-      description: |-
-        Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command.
-
-        <details>
-        <summary><strong>Tested Camera Models</strong></summary>
-
-        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
-
-        | Camera | Supported? &nbsp;&nbsp; | Notes |
-        |--------|:------------|-------|
-        | **Hikvision DFI6256TE** | ❌ |  |
-        | **Tapo C200** | ❌ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
-        | **GeoVision GV-BX8700** | ❌ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
-        </details>
       parameters:
       - name: jsonObject
         in: query
@@ -6212,13 +6248,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.GetProfiles
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AnalyticsConfigurations:
-    get:
-      tags:
-      - Analytics - Profile Configuration
-      summary: 'Media2: GetAnalyticsConfigurations'
       description: |-
-        By default this operation lists all existing video analytics configurations for a device. Provide a profile token to list only configurations that are compatible with the profile. If a configuration token is provided only a single configuration will be returned.
+        Retrieve the profile with the specified token or all defined media profiles.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6233,6 +6264,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AnalyticsConfigurations:
+    get:
+      tags:
+      - Analytics - Profile Configuration
+      summary: 'Media2: GetAnalyticsConfigurations'
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
       responses:
@@ -6347,15 +6383,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.GetAnalyticsConfigurations
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AddConfiguration:
-    put:
-      tags:
-      - Analytics - Profile Configuration
-      summary: 'Media2: AddConfiguration'
       description: |-
-        This operation adds one or more PTZConfigurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.
-
-        Note that OSD elements must be added via the CreateOSD command.
+        By default this operation lists all existing video analytics configurations for a device. Provide a profile token to list only configurations that are compatible with the profile. If a configuration token is provided only a single configuration will be returned.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6368,8 +6397,13 @@ paths:
         | **Tapo C200** | ❌ |  |
         | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
-        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ✔️ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2AddConfiguration:
+    put:
+      tags:
+      - Analytics - Profile Configuration
+      summary: 'Media2: AddConfiguration'
       requestBody:
         content:
           application/json:
@@ -6398,13 +6432,11 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.AddConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2RemoveConfiguration:
-    put:
-      tags:
-      - Analytics - Profile Configuration
-      summary: 'Media2: RemoveConfiguration'
       description: |-
-        This operation removes the listed configurations from an existing media profile. If the media profile does not contain one of the listed configurations that item shall be ignored.
+        This operation adds one or more Configurations to an existing media profile. If a
+        configuration exists in the media profile, it will be replaced. A device shall
+        support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall
+        support streaming video data of such a profile.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6419,6 +6451,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/Media2RemoveConfiguration:
+    put:
+      tags:
+      - Analytics - Profile Configuration
+      summary: 'Media2: RemoveConfiguration'
       requestBody:
         content:
           application/json:
@@ -6447,13 +6484,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/media/wsdl/media.wsdl#op.RemoveConfiguration
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SupportedAnalyticsModules:
-    get:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: GetSupportedAnalyticsModules'
       description: |-
-        List all analytics modules that are supported by the given VideoAnalyticsConfiguration.
+        This operation removes the listed configurations from an existing media profile. If the
+        				media profile does not contain one of the listed configurations that item shall be ignored.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6468,6 +6501,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/SupportedAnalyticsModules:
+    get:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: GetSupportedAnalyticsModules'
       parameters:
       - name: jsonObject
         in: query
@@ -6649,13 +6687,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetSupportedAnalyticsModules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsModules:
-    get:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: GetAnalyticsModules'
       description: |-
-        List the currently assigned set of analytics modules of a VideoAnalyticsConfiguration.
+        List all analytics modules that are supported by the given VideoAnalyticsConfiguration.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6670,6 +6703,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsModules:
+    get:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: GetAnalyticsModules'
       parameters:
       - name: jsonObject
         in: query
@@ -6791,12 +6829,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetAnalyticsModules
-    put:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: ModifyAnalyticsModules'
       description: |-
-        Modify the settings of one or more analytics modules of a VideoAnalyticsConfiguration. The modules are referenced by their names. It is allowed to pass only a subset to be modified.
+        List the currently assigned set of analytics modules of a VideoAnalyticsConfiguration.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6811,6 +6845,10 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+    put:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: ModifyAnalyticsModules'
       requestBody:
         content:
           application/json:
@@ -6843,19 +6881,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.ModifyAnalyticsModules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CreateAnalyticsModules:
-    put:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: CreateAnalyticsModules'
       description: |-
-        Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance.
-
-        Pass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.
-
-        Although this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and Media2AnalyticsConfigurations.
-
-        The device shall ensure that a corresponding analytics engine starts operation when a client subscribes directly or indirectly for events produced by the analytics or rule engine or when a client requests the corresponding scene description stream. An analytics module must be attached to a Video source using the media profiles before it can be used. In case differing analytics configurations are attached to the same profile it is undefined which of the analytics module configuration becomes active if no stream is activated or multiple streams with different profiles are activated at the same time.
+        Modify the settings of one or more analytics modules of a VideoAnalyticsConfiguration. The modules are referenced by their names.
+        				It is allowed to pass only a subset to be modified.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6866,10 +6894,15 @@ paths:
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
         | **Tapo C200** | ❌ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/CreateAnalyticsModules:
+    put:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: CreateAnalyticsModules'
       requestBody:
         content:
           application/json:
@@ -6902,13 +6935,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.CreateAnalyticsModules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DeleteAnalyticsModules:
-    put:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: DeleteAnalyticsModules'
       description: |-
-        Remove one or more analytics modules from a VideoAnalyticsConfiguration referenced by their names.
+        Add one or more analytics modules to an existing VideoAnalyticsConfiguration.
+        				The available supported types can be retrieved via
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6923,6 +6952,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/DeleteAnalyticsModules:
+    put:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: DeleteAnalyticsModules'
       requestBody:
         content:
           application/json:
@@ -6950,13 +6984,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.DeleteAnalyticsModules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsModuleOptions:
-    get:
-      tags:
-      - Analytics - Modules
-      summary: 'Analytics: GetAnalyticsModuleOptions'
       description: |-
-        Return the options for the supported analytics modules that specify an Option attribute.
+        Remove one or more analytics modules from a VideoAnalyticsConfiguration referenced by their names.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -6967,10 +6996,15 @@ paths:
         |--------|:------------|-------|
         | **Hikvision DFI6256TE** | ❌ |  |
         | **Tapo C200** | ❌ |  |
-        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ❌ |  |
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsModuleOptions:
+    get:
+      tags:
+      - Analytics - Modules
+      summary: 'Analytics: GetAnalyticsModuleOptions'
       parameters:
       - name: jsonObject
         in: query
@@ -7063,13 +7097,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetAnalyticsModuleOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsSupportedRules:
-    get:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: GetSupportedRules'
       description: |-
-        List all rules that are supported by the given VideoAnalyticsConfiguration.
+        Return the options for the supported analytics modules that specify an Option attribute.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7084,6 +7113,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsSupportedRules:
+    get:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: GetSupportedRules'
       parameters:
       - name: jsonObject
         in: query
@@ -7320,13 +7354,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetSupportedRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRules:
-    get:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: GetRules'
       description: |-
-        List the currently assigned set of rules of a VideoAnalyticsConfiguration.
+        List all rules that are supported by the given VideoAnalyticsConfiguration.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7341,6 +7370,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRules:
+    get:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: GetRules'
       parameters:
       - name: jsonObject
         in: query
@@ -7437,12 +7471,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetRules
-    put:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: ModifyRules'
       description: |-
-        Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names.
+        List the currently assigned set of rules of a VideoAnalyticsConfiguration.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7457,6 +7487,10 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+    put:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: ModifyRules'
       requestBody:
         content:
           application/json:
@@ -7489,13 +7523,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.ModifyRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRuleOptions:
-    get:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: GetRuleOptions'
       description: |-
-        Return the options for the supported rules that specify an Option attribute.
+        Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7510,6 +7539,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsRuleOptions:
+    get:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: GetRuleOptions'
       parameters:
       - name: jsonObject
         in: query
@@ -7605,17 +7639,8 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.GetRuleOptions
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsCreateRules:
-    put:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: CreateRules'
       description: |-
-        Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via AnalyticsSupportedRules, where the Name of the supported rule correspond to the type of an rule instance.
-
-        Pass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.
-
-        Although this method is mandatory a device implementation must not support adding rules. Instead it can provide a fixed set of predefined configurations via the media service function GetCompatibleVideoAnalyticsConfigurations.
+        Return the options for the supported rules that specify an Option attribute.
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7630,6 +7655,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsCreateRules:
+    put:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: CreateRules'
       requestBody:
         content:
           application/json:
@@ -7670,13 +7700,9 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.CreateRules
-  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsDeleteRules:
-    put:
-      tags:
-      - Analytics - Rules
-      summary: 'Analytics: DeleteRules'
       description: |-
-        Remove one or more rules from a VideoAnalyticsConfiguration.
+        Add one or more rules to an existing VideoAnalyticsConfiguration.
+        				The available supported types can be retrieved via
 
         <details>
         <summary><strong>Tested Camera Models</strong></summary>
@@ -7691,6 +7717,11 @@ paths:
         | **GeoVision GV-BX8700** | ❌ |  |
         | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
         </details>
+  /api/v3/device/name/{EDGEX_DEVICE_NAME}/AnalyticsDeleteRules:
+    put:
+      tags:
+      - Analytics - Rules
+      summary: 'Analytics: DeleteRules'
       requestBody:
         content:
           application/json:
@@ -7718,11 +7749,27 @@ paths:
       externalDocs:
         description: Onvif Specification
         url: https://www.onvif.org/ver20/analytics/wsdl/analytics.wsdl#op.DeleteRules
+      description: |-
+        Remove one or more rules from a VideoAnalyticsConfiguration.
+
+        <details>
+        <summary><strong>Tested Camera Models</strong></summary>
+
+        Below is a list of camera models that this command has been tested against, and whether or not the command is supported.
+
+        | Camera | Supported? &nbsp;&nbsp; | Notes |
+        |--------|:------------|-------|
+        | **Hikvision DFI6256TE** | ❌ |  |
+        | **Tapo C200** | ❌ |  |
+        | **BOSCH DINION IP starlight 6000 HD** | ✔️ |  |
+        | **GeoVision GV-BX8700** | ❌ |  |
+        | **Hikvision DS-2DE2A404IW-DE3** | ❌ |  |
+        </details>
   /api/v3/device/name/{EDGEX_DEVICE_NAME}/MACAddress:
     get:
       tags:
       - Custom
-      summary: Get MACAddress
+      summary: MACAddress
       description: This command returns the MAC address associated with a device.
       parameters:
       - $ref: '#/components/parameters/EDGEX_DEVICE_NAME'
@@ -7766,7 +7813,7 @@ paths:
     put:
       tags:
       - Custom
-      summary: Set MACAddress
+      summary: MACAddress
       description: >-
         MACAddress can also be set via Edgex device command. This is useful for
         setting the MAC Address for devices which do not contain 
@@ -7807,7 +7854,7 @@ paths:
     get:
       tags:
       - Custom
-      summary: Get FriendlyName
+      summary: FriendlyName
       description: >-
         This operation is used by an endpoint to get the FriendlyName from a
         device. This is a name given to a device by a user to make the device
@@ -7854,7 +7901,7 @@ paths:
     put:
       tags:
       - Custom
-      summary: Set FriendlyName
+      summary: FriendlyName
       description: >-
         This operation is used by an endpoint to set the FriendlyName of a
         device. This is a name given to a device by a user to make the device
@@ -7884,7 +7931,7 @@ paths:
     get:
       tags:
       - Custom
-      summary: Get CustomMetadata
+      summary: CustomMetadata
       description: >-
         **Get Custom Metadata**
 
@@ -7959,7 +8006,7 @@ paths:
                 $ref: '#/components/schemas/ObjectEventResponse'
               examples:
                 example-0:
-                  summary: Get CustomMetadata
+                  summary: CustomMetadata
                   value:
                     apiVersion: v3
                     statusCode: 200
@@ -8013,7 +8060,7 @@ paths:
     put:
       tags:
       - Custom
-      summary: Set CustomMetadata
+      summary: CustomMetadata
       description: >-
         Use the CustomMetadata resource to set the fields of `CustomMetadata`.
         Choose the key/value pairs to represent your custom fields.
@@ -8048,7 +8095,7 @@ paths:
     put:
       tags:
       - Custom
-      summary: Delete CustomMetadata
+      summary: DeleteCustomMetadata
       description: >-
         Use the `DeleteCustomMetadata` resource to delete entries in custom
         metadata

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "a11f95ea-4944-48df-bd2c-7e8a4ad5a260",
+		"_postman_id": "79e5804a-2979-4157-9973-8d25ad33986d",
 		"name": "device-onvif-camera",
 		"description": "The Open Network Video Interface Forum (ONVIF) Device Service is a microservice created to address the lack of standardization and automation of camera discovery and onboarding. EdgeX Foundry is a flexible microservice-based architecture created to promote the interoperability of multiple device interface combinations at the edge. In an EdgeX deployment, the ONVIF Device Service controls and communicates with ONVIF-compliant cameras, while EdgeX Foundry presents a standard interface to application developers. With normalized connectivity protocols and a vendor-neutral architecture, EdgeX paired with ONVIF Camera Device Service, simplifies deployment of edge camera devices.\n\nUse the ONVIF Device Service to streamline and scale your edge camera device deployment.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "11943447"
+		"_exporter_id": "7889146"
 	},
 	"item": [
 		{
@@ -602,13 +602,13 @@
 					]
 				},
 				{
-					"name": "Add Scopes",
+					"name": "Add Discovery Scopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"AddScopes\": {\n        \"ScopeItem\": [\n            \"http//:123\"\n        ]\n    }\n}",
+							"raw": "{\n    \"AddDiscoveryScopes\": {\n        \"ScopeItem\": [\n            \"http//:123\"\n        ]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -616,7 +616,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddScopes",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -631,7 +631,7 @@
 								"device",
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
-								"AddScopes"
+								"AddDiscoveryScopes"
 							]
 						},
 						"description": "This operation adds new configurable scope parameters to a device. The scope parameters are used in the device discovery to match a probe message. The device shall support addition of discovery scope parameters through the AddScopes command."
@@ -644,7 +644,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"AddScopes\":{\n        \"ScopeItem\":[\n            \"http//:123\"\n        ]\n    }\n}",
+									"raw": "{\n    \"AddDiscoveryScopes\":{\n        \"ScopeItem\":[\n            \"http//:123\"\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -652,7 +652,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddScopes",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -667,7 +667,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"AddScopes"
+										"AddDiscoveryScopes"
 									]
 								}
 							},
@@ -698,12 +698,12 @@
 					]
 				},
 				{
-					"name": "Get Scopes",
+					"name": "Get DiscoveryScopes",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Scopes",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -718,19 +718,19 @@
 								"device",
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
-								"Scopes"
+								"DiscoveryScopes"
 							]
 						},
 						"description": "This operation requests the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The Scope parameters are of two different types:  \n\\- Fixed  \n\\- Configurable  \nFixed scope parameters are permanent device characteristics and cannot be removed through the device management interface. The scope type is indicated in the scope list returned in the get scope parameters response. A device shall support retrieval of discovery scope parameters through the GetScopes command. As some scope parameters are mandatory, the device shall return a non-empty scope list in the response."
 					},
 					"response": [
 						{
-							"name": "Get Scopes",
+							"name": "Get DiscoveryScopes",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Scopes",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -745,7 +745,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Scopes"
+										"DiscoveryScopes"
 									]
 								}
 							},
@@ -771,18 +771,18 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"05f573f4-0836-45ad-b9ba-c393f9927586\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Scopes\",\n        \"origin\": 1659659228090509033,\n        \"readings\": [\n            {\n                \"id\": \"ea858652-cb16-432c-bf45-f9785cd00d85\",\n                \"origin\": 1659659228090509033,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Scopes\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Scopes\": [\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/name/TP-IPC\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/hardware/MODEL\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/Profile/Streaming\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/location/ShenZhen\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/type/NetworkVideoTransmitter\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"05f573f4-0836-45ad-b9ba-c393f9927586\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"DiscoveryScopes\",\n        \"origin\": 1659659228090509033,\n        \"readings\": [\n            {\n                \"id\": \"ea858652-cb16-432c-bf45-f9785cd00d85\",\n                \"origin\": 1659659228090509033,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"DiscoveryScopes\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Scopes\": [\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/name/TP-IPC\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/hardware/MODEL\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/Profile/Streaming\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/location/ShenZhen\"\n                        },\n                        {\n                            \"ScopeDef\": \"Fixed\",\n                            \"ScopeItem\": \"onvif://www.onvif.org/type/NetworkVideoTransmitter\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 						}
 					]
 				},
 				{
-					"name": "Put Scopes",
+					"name": "Put DiscoveryScopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"Scopes\": {\n        \"Scopes\": [\n            \"http//:123\"\n        ]\n    }\n}",
+							"raw": "{\n    \"DiscoveryScopes\": {\n        \"Scopes\": [\n            \"http//:123\"\n        ]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -790,7 +790,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Scopes",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -805,20 +805,20 @@
 								"device",
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
-								"Scopes"
+								"DiscoveryScopes"
 							]
 						},
 						"description": "This operation sets the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message. This operation replaces all existing configurable scope parameters (not fixed parameters). If this shall be avoided, one should use the scope add command instead."
 					},
 					"response": [
 						{
-							"name": "Put Scopes",
+							"name": "Put DiscoveryScopes",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Scopes\":{\n        \"Scopes\":[\n            \"http//:123\"\n        ]\n    }\n}",
+									"raw": "{\n    \"DiscoveryScopes\":{\n        \"Scopes\":[\n            \"http//:123\"\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -826,7 +826,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Scopes",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -841,7 +841,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Scopes"
+										"DiscoveryScopes"
 									]
 								}
 							},
@@ -872,13 +872,13 @@
 					]
 				},
 				{
-					"name": "Remove Scopes",
+					"name": "Remove DiscoveryScopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"RemoveScopes\": {\n        \"ScopeItem\": [\n            \"onvif://www.onvif.org/name/Geovision\"\n        ]\n    }\n}",
+							"raw": "{\n    \"RemoveDiscoveryScopes\": {\n        \"ScopeItem\": [\n            \"onvif://www.onvif.org/name/Geovision\"\n        ]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -886,7 +886,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveScopes",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -901,20 +901,20 @@
 								"device",
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
-								"RemoveScopes"
+								"RemoveDiscoveryScopes"
 							]
 						},
 						"description": "This operation deletes scope-configurable scope parameters from a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The device shall support deletion of discovery scope parameters through the RemoveScopes command"
 					},
 					"response": [
 						{
-							"name": "Remove Scopes",
+							"name": "Remove DiscoveryScopes",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"RemoveScopes\":{\n        \"ScopeItem\":[\n            \"onvif://www.onvif.org/name/Geovision\"\n        ]\n    }\n}",
+									"raw": "{\n    \"RemoveDiscoveryScopes\":{\n        \"ScopeItem\":[\n            \"onvif://www.onvif.org/name/Geovision\"\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -922,7 +922,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveScopes",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -937,7 +937,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"RemoveScopes"
+										"RemoveDiscoveryScopes"
 									]
 								}
 							},
@@ -963,7 +963,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"apiVersion\": \"v3\",\n    \"message\": \"request failed, status code: 500, err: {\\\"apiVersion\\\":\\\"v3\\\",\\\"message\\\":\\\"error writing DeviceResourece RemoveScopes for Intel-SimCamera-003caffe-6392-4bb2-a5a4-f027d2e89ee1 -\\\\u003e failed to execute write command, \\\\u003cnil\\\\u003e -\\\\u003e invalid request for the function 'RemoveScopes' of web service 'Device'. Onvif error: fault reason: Trying to Remove scope which does not exist, fault detail: , fault code: s:Sender ter:InvalidArgVal ter:NoScope\\\",\\\"statusCode\\\":500}\",\n    \"statusCode\": 500\n}"
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"message\": \"request failed, status code: 500, err: {\\\"apiVersion\\\":\\\"v3\\\",\\\"message\\\":\\\"error writing DeviceResourece RemoveDiscoveryScopes for Intel-SimCamera-003caffe-6392-4bb2-a5a4-f027d2e89ee1 -\\\\u003e failed to execute write command, \\\\u003cnil\\\\u003e -\\\\u003e invalid request for the function 'RemoveDiscoveryScopes' of web service 'Device'. Onvif error: fault reason: Trying to Remove scope which does not exist, fault detail: , fault code: s:Sender ter:InvalidArgVal ter:NoScope\\\",\\\"statusCode\\\":500}\",\n    \"statusCode\": 500\n}"
 						}
 					]
 				},
@@ -3609,7 +3609,7 @@
 			"name": "Video Streaming",
 			"item": [
 				{
-					"name": "Profiles",
+					"name": "MediaProfiles",
 					"protocolProfileBehavior": {
 						"disableBodyPruning": true
 					},
@@ -3626,7 +3626,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Profiles",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -3641,19 +3641,19 @@
 								"device",
 								"name",
 								"{{EDGEX_DEVICE_NAME}}",
-								"Profiles"
+								"MediaProfiles"
 							]
 						},
 						"description": "Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command."
 					},
 					"response": [
 						{
-							"name": "Profiles",
+							"name": "MediaProfiles",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Profiles",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -3668,7 +3668,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Profiles"
+										"MediaProfiles"
 									]
 								}
 							},
@@ -3694,7 +3694,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"e6560b52-1952-4d66-9f53-3cf27d48b3c0\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Profiles\",\n        \"origin\": 1659656314715442631,\n        \"readings\": [\n            {\n                \"id\": \"5c7bc03c-308f-4b2c-8bc9-2e59da7d6f65\",\n                \"origin\": 1659656314715442631,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Profiles\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Profiles\": [\n                        {\n                            \"AudioEncoderConfiguration\": {\n                                \"Bitrate\": 131072,\n                                \"Encoding\": \"G711\",\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"AudioEncoder_1\",\n                                \"SampleRate\": 8000,\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"microphone\",\n                                \"UseCount\": 2\n                            },\n                            \"AudioSourceConfiguration\": {\n                                \"Name\": \"AudioSourceConfig\",\n                                \"SourceToken\": \"raw_as1\",\n                                \"Token\": \"asconf\",\n                                \"UseCount\": 2\n                            },\n                            \"Extension\": null,\n                            \"Fixed\": true,\n                            \"MetadataConfiguration\": null,\n                            \"Name\": \"mainStream\",\n                            \"PTZConfiguration\": {\n                                \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"DefaultPTZSpeed\": {},\n                                \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                                \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"PanTiltLimits\": {\n                                    \"Range\": {\n                                        \"URI\": \"\",\n                                        \"XRange\": {\n                                            \"Max\": 170,\n                                            \"Min\": -170\n                                        },\n                                        \"YRange\": {\n                                            \"Max\": 35,\n                                            \"Min\": -32\n                                        }\n                                    }\n                                },\n                                \"Token\": \"PTZConfiguration0\"\n                            },\n                            \"Token\": \"profile_1\",\n                            \"VideoAnalyticsConfiguration\": {\n                                \"AnalyticsEngineConfiguration\": {\n                                    \"AnalyticsModule\": [\n                                        {\n                                            \"Name\": \"MyCellMotionModule\",\n                                            \"Parameters\": {\n                                                \"ElementItem\": [\n                                                    {\n                                                        \"Name\": \"Layout\"\n                                                    }\n                                                ],\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\",\n                                                        \"Value\": \"medium\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\",\n                                                        \"Value\": \"off\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:CellMotionEngine\"\n                                        },\n                                        {\n                                            \"Name\": \"MyTamperDetecModule\",\n                                            \"Parameters\": {\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:TamperEngine\"\n                                        }\n                                    ]\n                                },\n                                \"Name\": \"VideoAnalyticsName\",\n                                \"RuleEngineConfiguration\": {\n                                    \"Rule\": {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"0P8A8A==\"\n                                                },\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:TamperDetector\"\n                                    }\n                                },\n                                \"Token\": \"VideoAnalyticsToken\",\n                                \"UseCount\": 2\n                            },\n                            \"VideoEncoderConfiguration\": {\n                                \"Encoding\": \"H264\",\n                                \"H264\": {\n                                    \"GovLength\": 25,\n                                    \"H264Profile\": \"Main\"\n                                },\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"VideoEncoder_1\",\n                                \"Quality\": 3,\n                                \"RateControl\": {\n                                    \"BitrateLimit\": 1024,\n                                    \"EncodingInterval\": 1,\n                                    \"FrameRateLimit\": 15\n                                },\n                                \"Resolution\": {\n                                    \"Height\": 1080,\n                                    \"Width\": 1920\n                                },\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"main\",\n                                \"UseCount\": 1\n                            },\n                            \"VideoSourceConfiguration\": {\n                                \"Bounds\": {\n                                    \"Height\": 720,\n                                    \"Width\": 1280,\n                                    \"X\": 0,\n                                    \"Y\": 0\n                                },\n                                \"Extension\": null,\n                                \"Name\": \"VideoSourceConfig\",\n                                \"SourceToken\": \"raw_vs1\",\n                                \"Token\": \"vsconf\",\n                                \"UseCount\": 2,\n                                \"ViewMode\": \"\"\n                            }\n                        },\n                        {\n                            \"AudioEncoderConfiguration\": {\n                                \"Bitrate\": 131072,\n                                \"Encoding\": \"G711\",\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"AudioEncoder_1\",\n                                \"SampleRate\": 8000,\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"microphone\",\n                                \"UseCount\": 2\n                            },\n                            \"AudioSourceConfiguration\": {\n                                \"Name\": \"AudioSourceConfig\",\n                                \"SourceToken\": \"raw_as1\",\n                                \"Token\": \"asconf\",\n                                \"UseCount\": 2\n                            },\n                            \"Extension\": null,\n                            \"Fixed\": true,\n                            \"MetadataConfiguration\": null,\n                            \"Name\": \"minorStream\",\n                            \"PTZConfiguration\": {\n                                \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"DefaultPTZSpeed\": {},\n                                \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                                \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"PanTiltLimits\": {\n                                    \"Range\": {\n                                        \"URI\": \"\",\n                                        \"XRange\": {\n                                            \"Max\": 170,\n                                            \"Min\": -170\n                                        },\n                                        \"YRange\": {\n                                            \"Max\": 35,\n                                            \"Min\": -32\n                                        }\n                                    }\n                                },\n                                \"Token\": \"PTZConfiguration0\"\n                            },\n                            \"Token\": \"profile_2\",\n                            \"VideoAnalyticsConfiguration\": {\n                                \"AnalyticsEngineConfiguration\": {\n                                    \"AnalyticsModule\": [\n                                        {\n                                            \"Name\": \"MyCellMotionModule\",\n                                            \"Parameters\": {\n                                                \"ElementItem\": [\n                                                    {\n                                                        \"Name\": \"Layout\"\n                                                    }\n                                                ],\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\",\n                                                        \"Value\": \"medium\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\",\n                                                        \"Value\": \"off\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:CellMotionEngine\"\n                                        },\n                                        {\n                                            \"Name\": \"MyTamperDetecModule\",\n                                            \"Parameters\": {\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:TamperEngine\"\n                                        }\n                                    ]\n                                },\n                                \"Name\": \"VideoAnalyticsName\",\n                                \"RuleEngineConfiguration\": {\n                                    \"Rule\": {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"0P8A8A==\"\n                                                },\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:TamperDetector\"\n                                    }\n                                },\n                                \"Token\": \"VideoAnalyticsToken\",\n                                \"UseCount\": 2\n                            },\n                            \"VideoEncoderConfiguration\": {\n                                \"Encoding\": \"H264\",\n                                \"H264\": {\n                                    \"GovLength\": 25,\n                                    \"H264Profile\": \"Main\"\n                                },\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"VideoEncoder_2\",\n                                \"Quality\": 3,\n                                \"RateControl\": {\n                                    \"BitrateLimit\": 256,\n                                    \"EncodingInterval\": 1,\n                                    \"FrameRateLimit\": 15\n                                },\n                                \"Resolution\": {\n                                    \"Height\": 360,\n                                    \"Width\": 640\n                                },\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"minor\",\n                                \"UseCount\": 1\n                            },\n                            \"VideoSourceConfiguration\": {\n                                \"Bounds\": {\n                                    \"Height\": 720,\n                                    \"Width\": 1280,\n                                    \"X\": 0,\n                                    \"Y\": 0\n                                },\n                                \"Extension\": null,\n                                \"Name\": \"VideoSourceConfig\",\n                                \"SourceToken\": \"raw_vs1\",\n                                \"Token\": \"vsconf\",\n                                \"UseCount\": 2,\n                                \"ViewMode\": \"\"\n                            }\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"e6560b52-1952-4d66-9f53-3cf27d48b3c0\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"MediaProfiles\",\n        \"origin\": 1659656314715442631,\n        \"readings\": [\n            {\n                \"id\": \"5c7bc03c-308f-4b2c-8bc9-2e59da7d6f65\",\n                \"origin\": 1659656314715442631,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"MediaProfiles\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Profiles\": [\n                        {\n                            \"AudioEncoderConfiguration\": {\n                                \"Bitrate\": 131072,\n                                \"Encoding\": \"G711\",\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"AudioEncoder_1\",\n                                \"SampleRate\": 8000,\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"microphone\",\n                                \"UseCount\": 2\n                            },\n                            \"AudioSourceConfiguration\": {\n                                \"Name\": \"AudioSourceConfig\",\n                                \"SourceToken\": \"raw_as1\",\n                                \"Token\": \"asconf\",\n                                \"UseCount\": 2\n                            },\n                            \"Extension\": null,\n                            \"Fixed\": true,\n                            \"MetadataConfiguration\": null,\n                            \"Name\": \"mainStream\",\n                            \"PTZConfiguration\": {\n                                \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"DefaultPTZSpeed\": {},\n                                \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                                \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"PanTiltLimits\": {\n                                    \"Range\": {\n                                        \"URI\": \"\",\n                                        \"XRange\": {\n                                            \"Max\": 170,\n                                            \"Min\": -170\n                                        },\n                                        \"YRange\": {\n                                            \"Max\": 35,\n                                            \"Min\": -32\n                                        }\n                                    }\n                                },\n                                \"Token\": \"PTZConfiguration0\"\n                            },\n                            \"Token\": \"profile_1\",\n                            \"VideoAnalyticsConfiguration\": {\n                                \"AnalyticsEngineConfiguration\": {\n                                    \"AnalyticsModule\": [\n                                        {\n                                            \"Name\": \"MyCellMotionModule\",\n                                            \"Parameters\": {\n                                                \"ElementItem\": [\n                                                    {\n                                                        \"Name\": \"Layout\"\n                                                    }\n                                                ],\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\",\n                                                        \"Value\": \"medium\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\",\n                                                        \"Value\": \"off\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:CellMotionEngine\"\n                                        },\n                                        {\n                                            \"Name\": \"MyTamperDetecModule\",\n                                            \"Parameters\": {\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:TamperEngine\"\n                                        }\n                                    ]\n                                },\n                                \"Name\": \"VideoAnalyticsName\",\n                                \"RuleEngineConfiguration\": {\n                                    \"Rule\": {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"0P8A8A==\"\n                                                },\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:TamperDetector\"\n                                    }\n                                },\n                                \"Token\": \"VideoAnalyticsToken\",\n                                \"UseCount\": 2\n                            },\n                            \"VideoEncoderConfiguration\": {\n                                \"Encoding\": \"H264\",\n                                \"H264\": {\n                                    \"GovLength\": 25,\n                                    \"H264Profile\": \"Main\"\n                                },\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"VideoEncoder_1\",\n                                \"Quality\": 3,\n                                \"RateControl\": {\n                                    \"BitrateLimit\": 1024,\n                                    \"EncodingInterval\": 1,\n                                    \"FrameRateLimit\": 15\n                                },\n                                \"Resolution\": {\n                                    \"Height\": 1080,\n                                    \"Width\": 1920\n                                },\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"main\",\n                                \"UseCount\": 1\n                            },\n                            \"VideoSourceConfiguration\": {\n                                \"Bounds\": {\n                                    \"Height\": 720,\n                                    \"Width\": 1280,\n                                    \"X\": 0,\n                                    \"Y\": 0\n                                },\n                                \"Extension\": null,\n                                \"Name\": \"VideoSourceConfig\",\n                                \"SourceToken\": \"raw_vs1\",\n                                \"Token\": \"vsconf\",\n                                \"UseCount\": 2,\n                                \"ViewMode\": \"\"\n                            }\n                        },\n                        {\n                            \"AudioEncoderConfiguration\": {\n                                \"Bitrate\": 131072,\n                                \"Encoding\": \"G711\",\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"AudioEncoder_1\",\n                                \"SampleRate\": 8000,\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"microphone\",\n                                \"UseCount\": 2\n                            },\n                            \"AudioSourceConfiguration\": {\n                                \"Name\": \"AudioSourceConfig\",\n                                \"SourceToken\": \"raw_as1\",\n                                \"Token\": \"asconf\",\n                                \"UseCount\": 2\n                            },\n                            \"Extension\": null,\n                            \"Fixed\": true,\n                            \"MetadataConfiguration\": null,\n                            \"Name\": \"minorStream\",\n                            \"PTZConfiguration\": {\n                                \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"DefaultPTZSpeed\": {},\n                                \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                                \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"PanTiltLimits\": {\n                                    \"Range\": {\n                                        \"URI\": \"\",\n                                        \"XRange\": {\n                                            \"Max\": 170,\n                                            \"Min\": -170\n                                        },\n                                        \"YRange\": {\n                                            \"Max\": 35,\n                                            \"Min\": -32\n                                        }\n                                    }\n                                },\n                                \"Token\": \"PTZConfiguration0\"\n                            },\n                            \"Token\": \"profile_2\",\n                            \"VideoAnalyticsConfiguration\": {\n                                \"AnalyticsEngineConfiguration\": {\n                                    \"AnalyticsModule\": [\n                                        {\n                                            \"Name\": \"MyCellMotionModule\",\n                                            \"Parameters\": {\n                                                \"ElementItem\": [\n                                                    {\n                                                        \"Name\": \"Layout\"\n                                                    }\n                                                ],\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\",\n                                                        \"Value\": \"medium\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\",\n                                                        \"Value\": \"off\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:CellMotionEngine\"\n                                        },\n                                        {\n                                            \"Name\": \"MyTamperDetecModule\",\n                                            \"Parameters\": {\n                                                \"SimpleItem\": [\n                                                    {\n                                                        \"Name\": \"Sensitivity\"\n                                                    },\n                                                    {\n                                                        \"Name\": \"Enabled\"\n                                                    }\n                                                ]\n                                            },\n                                            \"Type\": \"tt:TamperEngine\"\n                                        }\n                                    ]\n                                },\n                                \"Name\": \"VideoAnalyticsName\",\n                                \"RuleEngineConfiguration\": {\n                                    \"Rule\": {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"0P8A8A==\"\n                                                },\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:TamperDetector\"\n                                    }\n                                },\n                                \"Token\": \"VideoAnalyticsToken\",\n                                \"UseCount\": 2\n                            },\n                            \"VideoEncoderConfiguration\": {\n                                \"Encoding\": \"H264\",\n                                \"H264\": {\n                                    \"GovLength\": 25,\n                                    \"H264Profile\": \"Main\"\n                                },\n                                \"Multicast\": {\n                                    \"Address\": {\n                                        \"IPv4Address\": \"0.0.0.0\",\n                                        \"Type\": \"IPv4\"\n                                    },\n                                    \"AutoStart\": false,\n                                    \"Port\": 0,\n                                    \"TTL\": 0\n                                },\n                                \"Name\": \"VideoEncoder_2\",\n                                \"Quality\": 3,\n                                \"RateControl\": {\n                                    \"BitrateLimit\": 256,\n                                    \"EncodingInterval\": 1,\n                                    \"FrameRateLimit\": 15\n                                },\n                                \"Resolution\": {\n                                    \"Height\": 360,\n                                    \"Width\": 640\n                                },\n                                \"SessionTimeout\": \"PT0H1M5S\",\n                                \"Token\": \"minor\",\n                                \"UseCount\": 1\n                            },\n                            \"VideoSourceConfiguration\": {\n                                \"Bounds\": {\n                                    \"Height\": 720,\n                                    \"Width\": 1280,\n                                    \"X\": 0,\n                                    \"Y\": 0\n                                },\n                                \"Extension\": null,\n                                \"Name\": \"VideoSourceConfig\",\n                                \"SourceToken\": \"raw_vs1\",\n                                \"Token\": \"vsconf\",\n                                \"UseCount\": 2,\n                                \"ViewMode\": \"\"\n                            }\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 						}
 					]
 				},
@@ -3875,6 +3875,96 @@
 							],
 							"cookie": [],
 							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"5fdf593f-2a92-4a71-b08c-791d7a27fdff\",\n        \"deviceName\": \"Intel-SimCamera-003caffe-6392-4bb2-a5a4-f027d2e89ee1\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Snapshot\",\n        \"origin\": 1665415500727830418,\n        \"readings\": [\n            {\n                \"id\": \"d04a9dad-feb9-4099-a524-8a4b4cf2cc37\",\n                \"origin\": 1665415500727830418,\n                \"deviceName\": \"Intel-SimCamera-003caffe-6392-4bb2-a5a4-f027d2e89ee1\",\n                \"resourceName\": \"Snapshot\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Binary\",\n                \"binaryValue\": \"/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACAAKADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDzGwiBtoGx/wAs1/kK0BGPSotPH+g23/XFP5CreKxOyOwxVqTYuOlAWn7eKQFd1VQDtH3hUgtoz1QUsq/u2PoM1PikBCLWL+4KelkhOQSAOp3dKoX+sQWalVO+X0HasB9bumOfMP0oDmR2T6c/klt/4d/5VRvNOkhxvQrkcblH4/rmsaz8TT25bzP3qMCNp7Z9K3IvGcU0C211F5kROTnG4dOh7dKYXTMPysXeMV0MKgDpVC4+xTXiy2QkMXPDNuI4rRgGcUBYsqgFSgUiLUoFMmwzbU8a0wLzVmMAimMlij713+h2a2lhEpX52G5vxrj9Nthc3kUJGQx5HtXoUaYFBUELIgYZ2ivLviHKJ47tAoxDAyj8ia9TkkWGF5HOFUc15H4oJm03UZW5LQyH9DTiKo9DmdPQ/YbbH/PFP5CrgWoNNP8AxLbX/rin8hVwVIR2GBacFp4UU8LSAryL8hqrqF4LTTTICN54XNaEi/Ka5LXpi8kcfZF6e5oAxXcscmoy1KetMaqSMGLuGacGqIU8A02gNK0vWhTAJByDXX6bMLiFXXvXBxiur8NSMZBGx+X0rKRvTd3Y6VBUyjirM1uoCOg4bP5j/IqMJirTHKNhgFSxjmgJTo1IamSdL4Xh3X5fH3Vrs8Yrl/Csf7yZ/Yf1rqyKGaIyddlMemOF43naa8419c6HqJx/y7Sf+gmvQPExItIVHQuc/lXB6+MeH9SP/TtJ/wCgmtYGFU5jTVH9mWn/AFxT+Qq2FqjppP8AZ1qP+mKfyFaS9KxNI7ABTgKUCngDFICMjiuG1cEXsoPrXdtiuP8AEUW25V/7wNBMjnj1ptPbrTcc1Zix8MZedR2zzVuWEKpUDBBp1lDj5z+FWbiA7t46GspT1OmnT0uVbOHfLg9K9G0Lw8xtYLuAr5chYZZuflxk1wtpFtkz2r03w5K7aBdRXczrHbyRNGuBwH3A4+vH6UblU9GdHe2sP2Nx5iBtxK57np/9euaxTjfSSjBOBTQaqBdRp7CgU9Rg01aeOtUYnV+FjzN9BXUiuS8Ln/SWX1WuvUc0MtGJ4nQ/Z7Y44yf6VwfiEY8P6l/17Sf+gmvR/ESb9MiOORJ/MH/CvP8AxGn/ABT2pHt9lk/9BNbwOeocPp0MzWFqwdR+5T+Qq4ILr+8lJpqj+zbP/rhH/wCg1eVaxNY7FURXX95Kf9nu/wC+lWwKkAqWhmU7XKnBWsvWIxJYuzD5lwRXTyRFkIUZasPVrO5Ns6LBISeOmR+lAmjidhJp6QMx6VrLpk0Ry8R/KmPHtbGMVnKdg5CONdiYFWuGhwagqzEm5BWL1N4qxNZoN4wK9C1R/M0jSQEVWNth2A5faxVc/QAVwtpGVbPpXpviH+zrTR9Ks1niFxDHlgvcNz/P+daxYmjnIweKsqKbGqkDBzU6rWyMhB0p69aAlSpHVNEm1oD7L+L3OK7pBXnunnyriJ/Rga9CRuhpFplTWofM05sdVIavPfEq48Nap/16S/8AoBr064QTwPGf4gRXm/iZMeGtVyOlpLn/AL5NaQdkY1Fc4fTR/wASyz/64R/+gitFU4qrpUQ/sqyZ8qot48+v3RVpbiVFkiixhxg5QE/gSMj8KzNI7DguFLZGB1yRU9ncWRLLc7xgfK688+mPSs1oHbr+tK6i3i3NwPWpGaUVxam4wqMAOjMe/wBKW8vbSGM+dIq56AnrXPPeSSf8e2UTvIR/IUiwRiOS6nbeQPvSck0mxsklubedW8mVW9s1nOFOeBVS65BuYE8tg33R3FSRP5ihgeDUNDI3t1ZvkGCe1WLa3YcEVNboplBIq/GirIDjjvUuJdN62Io4SozViOEzq4X74rUisEnjPkgucZwAc04RQ2MrJEfMZ12yHHAPfFZ6nZaJjQve2hyrnGehGQa7BrcMsUsQIiliWQE+pHI/A5H4VkSxqyHI6dvSum0TbqPh2W3zmeyJdB3MZ64+h5/GtoHNWguhnhcdadkZ4pWpoHNanMWYeor0G1ffBG2eqivPYuldxob79PXnOKBo0+1cL42h8rQ9ZHrZyn/xw13ijNcj4/hx4c1WT1sZh+SGriRI820qEyaZp/p9mj/9BFX/ALKELEjHyk1Z0qK3g8M6bPMQo+yQkk+6CqNzJc3zYhR0i6Db94/X0qTSOxBcXKR/u41MkvoOg+pqolpNeEGYb8fgo/DvWpDpSR7TIM8Z254/+vV4g8jtxxQBhLZbPv8AJxj2rO1k+UkcC/Vh/KukkT94KwdcXzbmCJRl8HP41IGBGXkcKo9eKfYj9y6n7ytW9Y6X9nUtImZT+lZWwWepTQkYWTFS0ImgilyCBVxGYfeHNWEgCqAKUw07DLNrfvAwaGRo3HQqcVNJ4j1JeWuBKAc/vYlfH0yKzfLxUU/EJpWK5mbNv4kt7ydY9StIgrHDS267Hx/ujg/lWnaXn/CO67b3sJM9jJkpIoIEsZ4I+o9PUVwg4OeldZ4d1GC7h/si+ZVhIzDKesT+v0PQ/wD1qaQc76nS3doslst/asj28nQK2Sh9D+uKoVZ0OO7sdSksJ4d0E64kiZlyfQqSeTyDx1pLu0ksrh4ZR8ynGexHqKohjI+ldd4ZkzbyR+hBrkYq6Xw04W4ZP7woBHVKOK5vx9Hu8Fas392zm/8AQDXTAVheN03+BtcA6ixmP/jhoTJkeZeHLO717TtOjJKWsFtEq8dwgGa6+TSI7WFYoo8d/c1ifDS8M1ra2RXIS3VgfbA6/mK7u5T94D6AD880zWOxxU0Oxm44BqnIPmf6VuXsWC59WNY7rjf+FANFJxjrWNEq3XiBuMiPp9f8mtq6bylZj0GKo+H7cOs923LSNwfYf/XzQKxcljwM4rkNfQpepMBkcv3tyMRmuU1yJpIjjtzQFjT2DaCPTNMJpdOzLpcUjctt5PrSN1pNA0Rmqs/3TVo1Vn+6akCi9EZ/eDmnPUaffBpCO80u7l1fTWtnAluI1zbydHXH8Oe4PTnuRWvaX8eu2yQ3Mu27hG1JG4Dj0Y/ng/nWH4UMQdAW2kNuVj0Hrn/Pb61P4gtRo2us8OPKb54+OxP9Dx+FaDZfMTRMVdSpBxg1q6LKIr6LJwCcU2yceIbMTmBI5EGxpI3ySccbl9Kr2hMcqHuDQQeg1i+M/wDkR9e/7B8//otq2QQyhhyCMg1jeMv+RH1//sHT/wDotqhEyPK/BVzNptnZ6pAhkighjS6XuFIHP0+6fqK9ZiCXUMkqOGVgpUjuMZz+teWeE3XTH0l35tru0ijnB6cxjr7cg13VnIfDepCwlY/2bdHNu78+W3dCfx4qzaOwavCqwu4HaudnGE3Y9K7PVYF+zyrjI25FchIM24GOQcH8KCjn9dfZa3PbGz9RV7TrT7JYRRbcYHP1qjrdu1zfQQJ/y3Khh64P+Ga2ieKDMqXY+Suc1FC6sAOororr7hrHukySfagaZR0K7zpzI3WJsEexq64RvmQ9e1ZGiyiLUrq2b+Mfyz/jWq8TQZK8x9vagZC/ANUZjk1cnOY2+lZrNkVBJHIeaYpwaefmBpi9aQjc0q+e2ZSDxmuo1S5i1rTkjRv9Ig+aMqOq/wAQ/kR9CPSuDSUoKtW+rzWjAxvg1SYzsfD815YKZIbqAQvjzY2BLcfh/UVsEICrxNlHG9T/AD/XIrz2PV5RNuAVAeyjArqfD9691DJGzjMeHUH0PDY/Hb+tO4HpumS+bpsDbs8YNUPGX/Ij6/8A9g6f/wBFtS+HHLWTgn7r8UnjL/kR9f8A+wdP/wCi2oM5H//Z\",\n                \"mediaType\": \"image/jpeg\",\n                \"value\": \"\"\n            }\n        ]\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "SnapshotUri",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://0.0.0.0:59989/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+							"protocol": "http",
+							"host": [
+								"0",
+								"0",
+								"0",
+								"0"
+							],
+							"port": "59989",
+							"path": [
+								"api",
+								"v3",
+								"device",
+								"name",
+								"{{EDGEX_DEVICE_NAME}}",
+								"SnapshotUri"
+							],
+							"query": [
+								{
+									"key": "jsonObject",
+									"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
+								}
+							]
+						},
+						"description": ""
+					},
+					"response": [
+						{
+							"name": "SnapshotUri",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+									"protocol": "http",
+									"host": [
+										"0",
+										"0",
+										"0",
+										"0"
+									],
+									"port": "59882",
+									"path": [
+										"api",
+										"v3",
+										"device",
+										"name",
+										"{{EDGEX_DEVICE_NAME}}",
+										"SnapshotUri"
+									],
+									"query": [
+										{
+											"key": "jsonObject",
+											"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Correlation-Id",
+									"value": ""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 10 May 2023 23:55:30 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "688"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"1a79ee51-c137-49b6-b884-a5450323850a\",\n        \"deviceName\": \"HIKVISION-DS-2DE2A404IW-DE3-099f4000-4d50-11b4-82c8-c06ded544d67\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"SnapshotUri\",\n        \"origin\": 1683762930988014759,\n        \"readings\": [\n            {\n                \"id\": \"de3e7c40-d705-4303-987f-d0b0feeffd0f\",\n                \"origin\": 1683762930988014759,\n                \"deviceName\": \"HIKVISION-DS-2DE2A404IW-DE3-099f4000-4d50-11b4-82c8-c06ded544d67\",\n                \"resourceName\": \"SnapshotUri\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"MediaUri\": {\n                        \"Uri\": \"http://10.0.0.165/onvif-http/snapshot?Profile_1\",\n                        \"InvalidAfterConnect\": false,\n                        \"InvalidAfterReboot\": false,\n                        \"Timeout\": \"PT0S\"\n                    }\n                }\n            }\n        ]\n    }\n}"
 						}
 					]
 				}
@@ -4258,12 +4348,12 @@
 					"name": "Capabilities",
 					"item": [
 						{
-							"name": "Nodes",
+							"name": "PTZNodes",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Nodes",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4278,19 +4368,19 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Nodes"
+										"PTZNodes"
 									]
 								},
 								"description": "Get the descriptions of the available PTZ Nodes.\n\nA PTZ-capable device may have multiple PTZ Nodes. The PTZ Nodes may represent mechanical PTZ drivers, uploaded PTZ drivers or digital PTZ drivers. PTZ Nodes are the lowest level entities in the PTZ control API and reflect the supported PTZ capabilities. The PTZ Node is referenced either by its name or by its reference token."
 							},
 							"response": [
 								{
-									"name": "Nodes",
+									"name": "PTZNodes",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Nodes",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4305,7 +4395,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Nodes"
+												"PTZNodes"
 											]
 										}
 									},
@@ -4331,17 +4421,17 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"dfe1b38e-1590-43c4-ab12-432ed5219476\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Nodes\",\n        \"origin\": 1659656363928092156,\n        \"readings\": [\n            {\n                \"id\": \"a47fe9e2-b007-4b5e-891b-3d50062b468f\",\n                \"origin\": 1659656363928092156,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Nodes\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZNode\": [\n                        {\n                            \"HomeSupported\": true,\n                            \"Name\": \"Node0\",\n                            \"SupportedPTZSpaces\": {\n                                \"AbsolutePanTiltPositionSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                },\n                                \"AbsoluteZoomPositionSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"ContinuousPanTiltVelocitySpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 1,\n                                        \"Min\": -1\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 1,\n                                        \"Min\": -1\n                                    }\n                                },\n                                \"ContinuousZoomVelocitySpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"Extension\": \"\",\n                                \"PanTiltSpeedSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"RelativePanTiltTranslationSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                },\n                                \"RelativeZoomTranslationSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"ZoomSpeedSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                }\n                            },\n                            \"Token\": \"Node0\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"dfe1b38e-1590-43c4-ab12-432ed5219476\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZNodes\",\n        \"origin\": 1659656363928092156,\n        \"readings\": [\n            {\n                \"id\": \"a47fe9e2-b007-4b5e-891b-3d50062b468f\",\n                \"origin\": 1659656363928092156,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZNodes\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZNode\": [\n                        {\n                            \"HomeSupported\": true,\n                            \"Name\": \"Node0\",\n                            \"SupportedPTZSpaces\": {\n                                \"AbsolutePanTiltPositionSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                },\n                                \"AbsoluteZoomPositionSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"ContinuousPanTiltVelocitySpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 1,\n                                        \"Min\": -1\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 1,\n                                        \"Min\": -1\n                                    }\n                                },\n                                \"ContinuousZoomVelocitySpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"Extension\": \"\",\n                                \"PanTiltSpeedSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"RelativePanTiltTranslationSpace\": {\n                                    \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                },\n                                \"RelativeZoomTranslationSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                },\n                                \"ZoomSpeedSpace\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 0,\n                                        \"Min\": 0\n                                    }\n                                }\n                            },\n                            \"Token\": \"Node0\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "Node",
+							"name": "PTZNode",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Node?jsonObject={{NODE_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4356,7 +4446,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Node"
+										"PTZNode"
 									],
 									"query": [
 										{
@@ -4370,12 +4460,12 @@
 							},
 							"response": [
 								{
-									"name": "Node",
+									"name": "PTZNode",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Node?jsonObject={{NODE_TOKEN_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4390,7 +4480,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Node"
+												"PTZNode"
 											],
 											"query": [
 												{
@@ -4422,17 +4512,17 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"713edf3b-f049-456b-8f3b-4a2dccca683f\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Node\",\n        \"origin\": 1659656370279599734,\n        \"readings\": [\n            {\n                \"id\": \"42af41ee-f72d-4f0c-95cf-0e8326f6d154\",\n                \"origin\": 1659656370279599734,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Node\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZNode\": {\n                        \"HomeSupported\": true,\n                        \"Name\": \"Node0\",\n                        \"SupportedPTZSpaces\": {\n                            \"AbsolutePanTiltPositionSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"AbsoluteZoomPositionSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ContinuousPanTiltVelocitySpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                },\n                                \"YRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                }\n                            },\n                            \"ContinuousZoomVelocitySpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"Extension\": \"\",\n                            \"PanTiltSpeedSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"RelativePanTiltTranslationSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"RelativeZoomTranslationSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ZoomSpeedSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            }\n                        },\n                        \"Token\": \"Node0\"\n                    }\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"713edf3b-f049-456b-8f3b-4a2dccca683f\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZNode\",\n        \"origin\": 1659656370279599734,\n        \"readings\": [\n            {\n                \"id\": \"42af41ee-f72d-4f0c-95cf-0e8326f6d154\",\n                \"origin\": 1659656370279599734,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZNode\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZNode\": {\n                        \"HomeSupported\": true,\n                        \"Name\": \"Node0\",\n                        \"SupportedPTZSpaces\": {\n                            \"AbsolutePanTiltPositionSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"AbsoluteZoomPositionSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ContinuousPanTiltVelocitySpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                },\n                                \"YRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                }\n                            },\n                            \"ContinuousZoomVelocitySpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"Extension\": \"\",\n                            \"PanTiltSpeedSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"RelativePanTiltTranslationSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"RelativeZoomTranslationSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ZoomSpeedSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            }\n                        },\n                        \"Token\": \"Node0\"\n                    }\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						}
 					]
 				},
 				{
-					"name": "Configuration",
+					"name": "PTZConfiguration",
 					"item": [
 						{
-							"name": "Configurations",
+							"name": "PTZConfigurations",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true
 							},
@@ -4441,7 +4531,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Node\":{\"NodeToken\": \"Node0\"}\n}",
+									"raw": "{\n    \"PTZNode\":{\"NodeToken\": \"Node0\"}\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4449,7 +4539,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configurations",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4464,19 +4554,19 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Configurations"
+										"PTZConfigurations"
 									]
 								},
 								"description": "Get all the existing PTZConfigurations from the device.  \nThe default Position/Translation/Velocity Spaces are introduced to allow NVCs sending move requests without the need to specify a certain coordinate system. The default Speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.  \nThe allowed pan and tilt range for Pan/Tilt Limits is defined by a two-dimensional space range that is mapped to a specific Absolute Pan/Tilt Position Space. At least one Pan/Tilt Position Space is required by the PTZNode to support Pan/Tilt limits. The limits apply to all supported absolute, relative and continuous Pan/Tilt movements. The limits shall be checked within the coordinate system for which the limits have been specified. That means that even if movements are specified in a different coordinate system, the requested movements shall be transformed to the coordinate system of the limits where the limits can be checked. When a relative or continuous movements is specified, which would leave the specified limits, the PTZ unit has to move along the specified limits. The Zoom Limits have to be interpreted accordingly."
 							},
 							"response": [
 								{
-									"name": "Configurations",
+									"name": "PTZConfigurations",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configurations",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4491,7 +4581,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Configurations"
+												"PTZConfigurations"
 											]
 										}
 									},
@@ -4517,7 +4607,7 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"b46d0e1e-f173-4bf0-8e35-984395952b09\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Configurations\",\n        \"origin\": 1659656376998679164,\n        \"readings\": [\n            {\n                \"id\": \"edf84087-d700-4967-bf5a-3e76e3c8ec18\",\n                \"origin\": 1659656376998679164,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Configurations\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfiguration\": [\n                        {\n                            \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                            \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                            \"DefaultPTZSpeed\": {},\n                            \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                            \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                            \"PanTiltLimits\": {\n                                \"Range\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                }\n                            },\n                            \"Token\": \"PTZConfiguration0\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"b46d0e1e-f173-4bf0-8e35-984395952b09\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZConfigurations\",\n        \"origin\": 1659656376998679164,\n        \"readings\": [\n            {\n                \"id\": \"edf84087-d700-4967-bf5a-3e76e3c8ec18\",\n                \"origin\": 1659656376998679164,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZConfigurations\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfiguration\": [\n                        {\n                            \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                            \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                            \"DefaultPTZSpeed\": {},\n                            \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                            \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                            \"PanTiltLimits\": {\n                                \"Range\": {\n                                    \"URI\": \"\",\n                                    \"XRange\": {\n                                        \"Max\": 170,\n                                        \"Min\": -170\n                                    },\n                                    \"YRange\": {\n                                        \"Max\": 35,\n                                        \"Min\": -32\n                                    }\n                                }\n                            },\n                            \"Token\": \"PTZConfiguration0\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
@@ -4531,7 +4621,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Node\":{\"NodeToken\": \"Node0\"}\n}",
+									"raw": "{\n    \"PTZNode\":{\"NodeToken\": \"Node0\"}\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4539,7 +4629,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configuration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4554,7 +4644,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Configuration"
+										"PTZConfiguration"
 									],
 									"query": [
 										{
@@ -4573,7 +4663,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configuration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4588,7 +4678,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Configuration"
+												"PTZConfiguration"
 											],
 											"query": [
 												{
@@ -4620,12 +4710,12 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"13f39ebb-cde4-4d99-bbc2-b207c4a40ca3\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Configuration\",\n        \"origin\": 1659656383599131308,\n        \"readings\": [\n            {\n                \"id\": \"3a5e5c97-268a-4c84-ae79-f51ada66889e\",\n                \"origin\": 1659656383599131308,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Configuration\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfiguration\": {\n                        \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                        \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                        \"DefaultPTZSpeed\": {},\n                        \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                        \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                        \"PanTiltLimits\": {\n                            \"Range\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            }\n                        },\n                        \"Token\": \"PTZConfiguration0\"\n                    }\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"13f39ebb-cde4-4d99-bbc2-b207c4a40ca3\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZConfiguration\",\n        \"origin\": 1659656383599131308,\n        \"readings\": [\n            {\n                \"id\": \"3a5e5c97-268a-4c84-ae79-f51ada66889e\",\n                \"origin\": 1659656383599131308,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZConfiguration\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfiguration\": {\n                        \"DefaultAbsolutePantTiltPositionSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                        \"DefaultContinuousPanTiltVelocitySpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                        \"DefaultPTZSpeed\": {},\n                        \"DefaultPTZTimeout\": \"PT0H0M20S\",\n                        \"DefaultRelativePanTiltTranslationSpace\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                        \"PanTiltLimits\": {\n                            \"Range\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            }\n                        },\n                        \"Token\": \"PTZConfiguration0\"\n                    }\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "ConfigurationOptions",
+							"name": "PTZConfigurationOptions",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true
 							},
@@ -4634,7 +4724,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Node\":{\"NodeToken\": \"Node0\"}\n}",
+									"raw": "{\n    \"PTZNode\":{\"NodeToken\": \"Node0\"}\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4642,7 +4732,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4657,7 +4747,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"ConfigurationOptions"
+										"PTZConfigurationOptions"
 									],
 									"query": [
 										{
@@ -4671,12 +4761,12 @@
 							},
 							"response": [
 								{
-									"name": "ConfigurationOptions",
+									"name": "PTZConfigurationOptions",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4691,7 +4781,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"ConfigurationOptions"
+												"PTZConfigurationOptions"
 											],
 											"query": [
 												{
@@ -4724,7 +4814,7 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"418fbbf5-6628-4033-8d7b-0811968dcee8\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"ConfigurationOptions\",\n        \"origin\": 1659671766926306082,\n        \"readings\": [\n            {\n                \"id\": \"7ceb7891-b7af-4cfe-9bbb-2d0fb3bead14\",\n                \"origin\": 1659671766926306082,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"ConfigurationOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfigurationOptions\": {\n                        \"PTZTimeout\": {\n                            \"Max\": \"PT0H0M20S\",\n                            \"Min\": \"PT0H0M20S\"\n                        },\n                        \"Spaces\": {\n                            \"AbsolutePanTiltPositionSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"AbsoluteZoomPositionSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ContinuousPanTiltVelocitySpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                },\n                                \"YRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                }\n                            },\n                            \"ContinuousZoomVelocitySpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"Extension\": \"\",\n                            \"PanTiltSpeedSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"RelativePanTiltTranslationSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"RelativeZoomTranslationSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ZoomSpeedSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"418fbbf5-6628-4033-8d7b-0811968dcee8\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZConfigurationOptions\",\n        \"origin\": 1659671766926306082,\n        \"readings\": [\n            {\n                \"id\": \"7ceb7891-b7af-4cfe-9bbb-2d0fb3bead14\",\n                \"origin\": 1659671766926306082,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZConfigurationOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfigurationOptions\": {\n                        \"PTZTimeout\": {\n                            \"Max\": \"PT0H0M20S\",\n                            \"Min\": \"PT0H0M20S\"\n                        },\n                        \"Spaces\": {\n                            \"AbsolutePanTiltPositionSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"AbsoluteZoomPositionSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ContinuousPanTiltVelocitySpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                },\n                                \"YRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": -1\n                                }\n                            },\n                            \"ContinuousZoomVelocitySpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"Extension\": \"\",\n                            \"PanTiltSpeedSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/GenericSpeedSpace\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"RelativePanTiltTranslationSpace\": {\n                                \"URI\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/TranslationGenericSpace\",\n                                \"XRange\": {\n                                    \"Max\": 170,\n                                    \"Min\": -170\n                                },\n                                \"YRange\": {\n                                    \"Max\": 35,\n                                    \"Min\": -32\n                                }\n                            },\n                            \"RelativeZoomTranslationSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            },\n                            \"ZoomSpeedSpace\": {\n                                \"URI\": \"\",\n                                \"XRange\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
@@ -4735,7 +4825,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Configuration\": {\n        \"PTZConfiguration\": {\n            \"Token\": \"{{PTZ_CONFIG_TOKEN}}\",\n            \"NodeToken\": \"{{PTZ_NODE_TOKEN}}\",\n            \"PanTiltLimits\": {\n                \"Range\": {\n                    \"XRange\": {\n                        \"Max\": 170,\n                        \"Min\": -170\n                    },\n                    \"YRange\": {\n                        \"Max\": 35,\n                        \"Min\": -32\n                    }\n                }\n            }\n        }\n    }\n}",
+									"raw": "{\n    \"PTZConfiguration\": {\n        \"PTZConfiguration\": {\n            \"Token\": \"{{PTZ_CONFIG_TOKEN}}\",\n            \"NodeToken\": \"{{PTZ_NODE_TOKEN}}\",\n            \"PanTiltLimits\": {\n                \"Range\": {\n                    \"XRange\": {\n                        \"Max\": 170,\n                        \"Min\": -170\n                    },\n                    \"YRange\": {\n                        \"Max\": 35,\n                        \"Min\": -32\n                    }\n                }\n            }\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4743,7 +4833,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configuration",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -4758,7 +4848,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Configuration"
+										"PTZConfiguration"
 									]
 								},
 								"description": "Set/update a existing PTZConfiguration on the device."
@@ -4771,7 +4861,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"Configuration\": {\n        \"PTZConfiguration\": {\n            \"Token\": \"{{PTZ_CONFIG_TOKEN}}\",\n            \"NodeToken\": \"{{PTZ_NODE_TOKEN}}\",\n            \"PanTiltLimits\": {\n                \"Range\": {\n                    \"XRange\": {\n                        \"Max\": 170,\n                        \"Min\": -170\n                    },\n                    \"YRange\": {\n                        \"Max\": 35,\n                        \"Min\": -32\n                    }\n                }\n            }\n        }                    \n    }\n}",
+											"raw": "{\n    \"PTZConfiguration\": {\n        \"PTZConfiguration\": {\n            \"Token\": \"{{PTZ_CONFIG_TOKEN}}\",\n            \"NodeToken\": \"{{PTZ_NODE_TOKEN}}\",\n            \"PanTiltLimits\": {\n                \"Range\": {\n                    \"XRange\": {\n                        \"Max\": 170,\n                        \"Min\": -170\n                    },\n                    \"YRange\": {\n                        \"Max\": 35,\n                        \"Min\": -32\n                    }\n                }\n            }\n        }                    \n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -4779,7 +4869,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Configuration",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -4794,7 +4884,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Configuration"
+												"PTZConfiguration"
 											]
 										}
 									},
@@ -5022,13 +5112,13 @@
 					"name": "Actuation",
 					"item": [
 						{
-							"name": "AbsoluteMove",
+							"name": "PTZAbsoluteMove",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"AbsoluteMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Position\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }\n    }\n}",
+									"raw": "{\n    \"PTZAbsoluteMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Position\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5036,7 +5126,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AbsoluteMove",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5051,20 +5141,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"AbsoluteMove"
+										"PTZAbsoluteMove"
 									]
 								},
 								"description": "Operation to move pan,tilt or zoom to a absolute destination.\n\nThe speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used."
 							},
 							"response": [
 								{
-									"name": "AbsoluteMove",
+									"name": "PTZAbsoluteMove",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"AbsoluteMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Position\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }               \n    }\n}",
+											"raw": "{\n    \"PTZAbsoluteMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Position\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }               \n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5072,7 +5162,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AbsoluteMove",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5087,7 +5177,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"AbsoluteMove"
+												"PTZAbsoluteMove"
 											]
 										}
 									},
@@ -5118,13 +5208,13 @@
 							]
 						},
 						{
-							"name": "RelativeMove",
+							"name": "PTZRelativeMove",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"RelativeMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Translation\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }\n    }\n}",
+									"raw": "{\n    \"PTZRelativeMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Translation\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5132,7 +5222,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RelativeMove",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5147,20 +5237,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"RelativeMove"
+										"PTZRelativeMove"
 									]
 								},
 								"description": "Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space.\n\nThe speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used."
 							},
 							"response": [
 								{
-									"name": "RelativeMove",
+									"name": "PTZRelativeMove",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"RelativeMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Translation\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }               \n    }\n}",
+											"raw": "{\n    \"PTZRelativeMove\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Translation\": {\n            \"PanTilt\": {\n                \"x\": 0,\n                \"y\": 0\n            }\n        }               \n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5168,7 +5258,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RelativeMove",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5183,7 +5273,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"RelativeMove"
+												"PTZRelativeMove"
 											]
 										}
 									},
@@ -5214,13 +5304,13 @@
 							]
 						},
 						{
-							"name": "ContinuousMove",
+							"name": "PTZContinuousMove",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"ContinuousMove\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"Velocity\": {\n            \"PanTilt\": {\n                \"x\": -1,\n                \"y\": -1\n            }\n        }\n    }\n}",
+									"raw": "{\n    \"PTZContinuousMove\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"Velocity\": {\n            \"PanTilt\": {\n                \"x\": -1,\n                \"y\": -1\n            }\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5228,7 +5318,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ContinuousMove",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5243,20 +5333,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"ContinuousMove"
+										"PTZContinuousMove"
 									]
 								},
 								"description": "Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used."
 							},
 							"response": [
 								{
-									"name": "ContinuousMove",
+									"name": "PTZContinuousMove",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"ContinuousMove\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"Velocity\": {\n            \"PanTilt\": {\n                \"x\": -1,\n                \"y\": -1\n            }\n        }               \n    }\n}",
+											"raw": "{\n    \"PTZContinuousMove\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"Velocity\": {\n            \"PanTilt\": {\n                \"x\": -1,\n                \"y\": -1\n            }\n        }               \n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5264,7 +5354,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ContinuousMove",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5279,7 +5369,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"ContinuousMove"
+												"PTZContinuousMove"
 											]
 										}
 									},
@@ -5310,7 +5400,7 @@
 							]
 						},
 						{
-							"name": "Status",
+							"name": "PTZStatus",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true
 							},
@@ -5327,7 +5417,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Status?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5342,7 +5432,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Status"
+										"PTZStatus"
 									],
 									"query": [
 										{
@@ -5356,12 +5446,12 @@
 							},
 							"response": [
 								{
-									"name": "Status",
+									"name": "PTZStatus",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Status?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5376,7 +5466,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Status"
+												"PTZStatus"
 											],
 											"query": [
 												{
@@ -5408,18 +5498,18 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"c8ad64b4-db58-4c9b-9896-82fff02544c9\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Status\",\n        \"origin\": 1659659252963492133,\n        \"readings\": [\n            {\n                \"id\": \"71444c1c-9e85-4852-9c1e-9bd9eba8d616\",\n                \"origin\": 1659659252963492133,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Status\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZStatus\": {\n                        \"MoveStatus\": {\n                            \"PanTilt\": \"IDLE\"\n                        },\n                        \"Position\": {\n                            \"PanTilt\": {\n                                \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"X\": 82,\n                                \"Y\": -5\n                            }\n                        },\n                        \"UtcTime\": \"2022-08-05T00:27:32Z\"\n                    }\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"c8ad64b4-db58-4c9b-9896-82fff02544c9\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZStatus\",\n        \"origin\": 1659659252963492133,\n        \"readings\": [\n            {\n                \"id\": \"71444c1c-9e85-4852-9c1e-9bd9eba8d616\",\n                \"origin\": 1659659252963492133,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZStatus\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZStatus\": {\n                        \"MoveStatus\": {\n                            \"PanTilt\": \"IDLE\"\n                        },\n                        \"Position\": {\n                            \"PanTilt\": {\n                                \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                \"X\": 82,\n                                \"Y\": -5\n                            }\n                        },\n                        \"UtcTime\": \"2022-08-05T00:27:32Z\"\n                    }\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "Stop",
+							"name": "PTZStop",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Stop\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PanTilt\": true\n    }\n}",
+									"raw": "{\n    \"PTZStop\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PanTilt\": true\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5427,7 +5517,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Stop",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5442,20 +5532,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Stop"
+										"PTZStop"
 									]
 								},
 								"description": "Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type. If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements."
 							},
 							"response": [
 								{
-									"name": "Stop",
+									"name": "PTZStop",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"Stop\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PanTilt\": true              \n    }\n}",
+											"raw": "{\n    \"PTZStop\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PanTilt\": true              \n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5463,7 +5553,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Stop",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5478,7 +5568,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Stop"
+												"PTZStop"
 											]
 										}
 									},
@@ -5511,7 +5601,7 @@
 					]
 				},
 				{
-					"name": "Preset",
+					"name": "PTZPreset",
 					"item": [
 						{
 							"name": "SetPreset",
@@ -5528,7 +5618,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Preset",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPreset",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5543,7 +5633,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Preset"
+										"PTZPreset"
 									]
 								},
 								"description": "The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation."
@@ -5610,12 +5700,12 @@
 							]
 						},
 						{
-							"name": "Presets",
+							"name": "PTZPresets",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Presets?jsonObject={{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5630,7 +5720,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Presets"
+										"PTZPresets"
 									],
 									"query": [
 										{
@@ -5643,12 +5733,12 @@
 							},
 							"response": [
 								{
-									"name": "Presets",
+									"name": "PTZPresets",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Presets?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5663,7 +5753,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Presets"
+												"PTZPresets"
 											],
 											"query": [
 												{
@@ -5695,18 +5785,18 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"79dde7e3-9730-4d33-aa9f-48e499b23207\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Presets\",\n        \"origin\": 1659659260936957116,\n        \"readings\": [\n            {\n                \"id\": \"5816a933-ec39-4c58-b8cf-aa3fc8dcbd19\",\n                \"origin\": 1659659260936957116,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"Presets\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Preset\": [\n                        {\n                            \"Name\": \"Marked Position 2\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 169,\n                                    \"Y\": -5\n                                }\n                            },\n                            \"Token\": \"Preset2\"\n                        },\n                        {\n                            \"Name\": \"Marked Position 3\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 115,\n                                    \"Y\": 13\n                                }\n                            },\n                            \"Token\": \"Preset3\"\n                        },\n                        {\n                            \"Name\": \"preset4\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 134,\n                                    \"Y\": 13\n                                }\n                            },\n                            \"Token\": \"Preset4\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"79dde7e3-9730-4d33-aa9f-48e499b23207\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"PTZPresets\",\n        \"origin\": 1659659260936957116,\n        \"readings\": [\n            {\n                \"id\": \"5816a933-ec39-4c58-b8cf-aa3fc8dcbd19\",\n                \"origin\": 1659659260936957116,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"PTZPresets\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Preset\": [\n                        {\n                            \"Name\": \"Marked Position 2\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 169,\n                                    \"Y\": -5\n                                }\n                            },\n                            \"Token\": \"Preset2\"\n                        },\n                        {\n                            \"Name\": \"Marked Position 3\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 115,\n                                    \"Y\": 13\n                                }\n                            },\n                            \"Token\": \"Preset3\"\n                        },\n                        {\n                            \"Name\": \"preset4\",\n                            \"PTZPosition\": {\n                                \"PanTilt\": {\n                                    \"Space\": \"http://www.onvif.org/ver10/tptz/PanTiltSpaces/PositionGenericSpace\",\n                                    \"X\": 134,\n                                    \"Y\": 13\n                                }\n                            },\n                            \"Token\": \"Preset4\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "GotoPreset",
+							"name": "PTZGotoPreset",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"GotoPreset\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"PresetToken\": \"Preset1\"\n    }\n}",
+									"raw": "{\n    \"PTZGotoPreset\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"PresetToken\": \"Preset1\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5714,7 +5804,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/GotoPreset",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoPreset",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5729,7 +5819,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"GotoPreset"
+										"PTZGotoPreset"
 									]
 								},
 								"description": "Operation to go to a saved preset position for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode."
@@ -5737,13 +5827,13 @@
 							"response": []
 						},
 						{
-							"name": "RemovePreset",
+							"name": "PTZRemovePreset",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"RemovePreset\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PresetToken\": \"Preset1\"\n    }\n}",
+									"raw": "{\n    \"PTZRemovePreset\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"PresetToken\": \"Preset1\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5751,7 +5841,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemovePreset",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRemovePreset",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5766,7 +5856,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"RemovePreset"
+										"PTZRemovePreset"
 									]
 								},
 								"description": "Operation to remove a PTZ preset for the Node in the selected profile. The operation is supported if the PresetPosition capability exists for teh Node in the selected profile."
@@ -5779,13 +5869,13 @@
 					"name": "Home Position",
 					"item": [
 						{
-							"name": "GotoHomePosition",
+							"name": "PTZGotoHomePosition",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"GotoHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
+									"raw": "{\n    \"PTZGotoHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5793,7 +5883,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/GotoHomePosition",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5808,20 +5898,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"GotoHomePosition"
+										"PTZGotoHomePosition"
 									]
 								},
 								"description": "Operation to move the PTZ device to it's \"home\" position. The operation is supported if the HomeSupported element in the PTZNode is true."
 							},
 							"response": [
 								{
-									"name": "GotoHomePosition",
+									"name": "PTZGotoHomePosition",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"GotoHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
+											"raw": "{\n    \"PTZGotoHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5829,7 +5919,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/GotoHomePosition",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5844,7 +5934,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"GotoHomePosition"
+												"PTZGotoHomePosition"
 											]
 										}
 									},
@@ -5875,13 +5965,13 @@
 							]
 						},
 						{
-							"name": "HomePosition",
+							"name": "PTZHomePosition",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"HomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
+									"raw": "{\n    \"PTZHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5889,7 +5979,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/HomePosition",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -5904,20 +5994,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"HomePosition"
+										"PTZHomePosition"
 									]
 								},
-								"description": "Operation to save current position as the home position. The HomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the HomePosition is successful, it is possible to recall the Home Position with the GotoHomePosition command."
+								"description": "Operation to save current position as the home position. The PTZHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the PTZHomePosition is successful, it is possible to recall the Home Position with the PTZGotoHomePosition command."
 							},
 							"response": [
 								{
-									"name": "HomePosition",
+									"name": "PTZHomePosition",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"HomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
+											"raw": "{\n    \"PTZHomePosition\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5925,7 +6015,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/HomePosition",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -5940,7 +6030,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"HomePosition"
+												"PTZHomePosition"
 											]
 										}
 									},
@@ -5976,13 +6066,13 @@
 					"name": "Auxiliary",
 					"item": [
 						{
-							"name": "SendAuxiliaryCommand",
+							"name": "PTZSendAuxiliaryCommand",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"SendAuxiliaryCommand\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"AuxiliaryData\": \"123\"\n    }\n}",
+									"raw": "{\n    \"PTZSendAuxiliaryCommand\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"AuxiliaryData\": \"123\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5990,7 +6080,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SendAuxiliaryCommand",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -6005,20 +6095,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"SendAuxiliaryCommand"
+										"PTZSendAuxiliaryCommand"
 									]
 								},
 								"description": "Manage auxiliary commands supported by a device, such as controlling an Infrared (IR) lamp, a heater or a wiper or a thermometer that is connected to the device.\n\nThe supported commands can be retrieved via the AuxiliaryCommands capability.\n\nAlthough the name of the auxiliary commands can be freely defined, commands starting with the prefix tt: are reserved to define frequently used commands and these reserved commands shall all share the \"tt:command|parameter\" syntax.  \ntt:Wiper|On – Request to start the wiper.  \ntt:Wiper|Off – Request to stop the wiper.  \ntt:Washer|On – Request to start the washer.  \ntt:Washer|Off – Request to stop the washer.  \ntt:WashingProcedure|On – Request to start the washing procedure.  \ntt: WashingProcedure |Off – Request to stop the washing procedure.  \ntt:IRLamp|On – Request to turn ON an IR illuminator attached to the unit.  \ntt:IRLamp|Off – Request to turn OFF an IR illuminator attached to the unit.  \ntt:IRLamp|Auto – Request to configure an IR illuminator attached to the unit so that it automatically turns ON and OFF.  \nA device that indicates auxiliary service capability shall support this command."
 							},
 							"response": [
 								{
-									"name": "SendAuxiliaryCommand",
+									"name": "PTZSendAuxiliaryCommand",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"SendAuxiliaryCommand\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"AuxiliaryData\": \"123\"\n    }\n}",
+											"raw": "{\n    \"PTZSendAuxiliaryCommand\": {\n        \"ProfileToken\": \"{{MEDIA_PROFILE}}\",\n        \"AuxiliaryData\": \"123\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -6026,7 +6116,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SendAuxiliaryCommand",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -6041,7 +6131,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"SendAuxiliaryCommand"
+												"PTZSendAuxiliaryCommand"
 											]
 										}
 									},
@@ -6531,12 +6621,12 @@
 							]
 						},
 						{
-							"name": "AnalyticsConfigurations",
+							"name": "Media2AnalyticsConfigurations",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsConfigurations",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -6551,19 +6641,19 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"AnalyticsConfigurations"
+										"Media2AnalyticsConfigurations"
 									]
 								},
 								"description": "By default this operation lists all existing video analytics configurations for a device. Provide a profile token to list only configurations that are compatible with the profile. If a configuration token is provided only a single configuration will be returned."
 							},
 							"response": [
 								{
-									"name": "AnalyticsConfigurations",
+									"name": "Media2AnalyticsConfigurations",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsConfigurations",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -6578,7 +6668,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"AnalyticsConfigurations"
+												"Media2AnalyticsConfigurations"
 											]
 										}
 									},
@@ -6604,18 +6694,18 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"08db4d59-0991-4ace-bb6a-9103c54d38ea\",\n        \"deviceName\": \"HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"AnalyticsConfigurations\",\n        \"origin\": 1664440527648299236,\n        \"readings\": [\n            {\n                \"id\": \"6e768a1a-a521-47c6-9d13-2337386768d1\",\n                \"origin\": 1664440527648299236,\n                \"deviceName\": \"HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c\",\n                \"resourceName\": \"AnalyticsConfigurations\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Configurations\": [\n                        {\n                            \"AnalyticsEngineConfiguration\": {\n                                \"AnalyticsModule\": [\n                                    {\n                                        \"Name\": \"MyCellMotionModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"0\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:CellMotionEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyLineDetectorModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"50\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:LineDetectorEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyFieldDetectorModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"50\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:FieldDetectorEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyTamperDetecModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Transformation\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"0\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"hikxsd:TamperEngine\"\n                                    }\n                                ]\n                            },\n                            \"Name\": \"VideoAnalyticsName\",\n                            \"RuleEngineConfiguration\": {\n                                \"Rule\": [\n                                    {\n                                        \"Name\": \"MyMotionDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"zwA=\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:CellMotionDetector\"\n                                    },\n                                    {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"hikxsd:TamperDetector\"\n                                    }\n                                ]\n                            },\n                            \"Token\": \"VideoAnalyticsToken\",\n                            \"UseCount\": 3\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"08db4d59-0991-4ace-bb6a-9103c54d38ea\",\n        \"deviceName\": \"HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Media2AnalyticsConfigurations\",\n        \"origin\": 1664440527648299236,\n        \"readings\": [\n            {\n                \"id\": \"6e768a1a-a521-47c6-9d13-2337386768d1\",\n                \"origin\": 1664440527648299236,\n                \"deviceName\": \"HIKVISION-DS-2DC4223IW-DE-3bd4c000-b1b9-11b3-8202-4cf5dc64a22c\",\n                \"resourceName\": \"Media2AnalyticsConfigurations\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"PTZConfigurations\": [\n                        {\n                            \"AnalyticsEngineConfiguration\": {\n                                \"AnalyticsModule\": [\n                                    {\n                                        \"Name\": \"MyCellMotionModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"0\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:CellMotionEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyLineDetectorModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"50\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:LineDetectorEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyFieldDetectorModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Layout\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"50\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:FieldDetectorEngine\"\n                                    },\n                                    {\n                                        \"Name\": \"MyTamperDetecModule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Transformation\"\n                                                },\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ],\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"Sensitivity\",\n                                                    \"Value\": \"0\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"hikxsd:TamperEngine\"\n                                    }\n                                ]\n                            },\n                            \"Name\": \"VideoAnalyticsName\",\n                            \"RuleEngineConfiguration\": {\n                                \"Rule\": [\n                                    {\n                                        \"Name\": \"MyMotionDetectorRule\",\n                                        \"Parameters\": {\n                                            \"SimpleItem\": [\n                                                {\n                                                    \"Name\": \"MinCount\",\n                                                    \"Value\": \"5\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOnDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"AlarmOffDelay\",\n                                                    \"Value\": \"1000\"\n                                                },\n                                                {\n                                                    \"Name\": \"ActiveCells\",\n                                                    \"Value\": \"zwA=\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"tt:CellMotionDetector\"\n                                    },\n                                    {\n                                        \"Name\": \"MyTamperDetectorRule\",\n                                        \"Parameters\": {\n                                            \"ElementItem\": [\n                                                {\n                                                    \"Name\": \"Field\"\n                                                }\n                                            ]\n                                        },\n                                        \"Type\": \"hikxsd:TamperDetector\"\n                                    }\n                                ]\n                            },\n                            \"Token\": \"VideoAnalyticsToken\",\n                            \"UseCount\": 3\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "AddConfiguration",
+							"name": "Media2AddConfiguration",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"AddConfiguration\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Configuration\": [\n            {\n                \"Type\": \"Analytics\",\n                \"Token\": \"{{ANALYTIC_CONFIG_TOKEN}}\"\n            }\n        ]\n    }\n}",
+									"raw": "{\n    \"Media2AddConfiguration\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Configuration\": [\n            {\n                \"Type\": \"Analytics\",\n                \"Token\": \"{{ANALYTIC_CONFIG_TOKEN}}\"\n            }\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6623,7 +6713,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddConfiguration",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AddConfiguration",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -6638,21 +6728,21 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"AddConfiguration"
+										"Media2AddConfiguration"
 									]
 								},
-								"description": "This operation adds one or more Configurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.\n\nNote that OSD elements must be added via the CreateOSD command."
+								"description": "This operation adds one or more PTZConfigurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.\n\nNote that OSD elements must be added via the CreateOSD command."
 							},
 							"response": []
 						},
 						{
-							"name": "RemoveConfiguration",
+							"name": "Media2RemoveConfiguration",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"RemoveConfiguration\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Configuration\": [\n            {\n                \"Type\": \"Analytics\",\n                \"Token\": \"{{ANALYTIC_CONFIG_TOKEN}}\"\n            }\n        ]\n    }\n}",
+									"raw": "{\n    \"Media2RemoveConfiguration\": {\n        \"ProfileToken\": \"{{PTZ_CONFIG_TOKEN}}\",\n        \"Configuration\": [\n            {\n                \"Type\": \"Analytics\",\n                \"Token\": \"{{ANALYTIC_CONFIG_TOKEN}}\"\n            }\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6660,7 +6750,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveConfiguration",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2RemoveConfiguration",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -6675,7 +6765,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"RemoveConfiguration"
+										"Media2RemoveConfiguration"
 									]
 								},
 								"description": "This operation removes the listed configurations from an existing media profile. If the media profile does not contain one of the listed configurations that item shall be ignored."
@@ -6888,7 +6978,7 @@
 										"CreateAnalyticsModules"
 									]
 								},
-								"description": "Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.\n\nAlthough this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and AnalyticsConfigurations.\n\nThe device shall ensure that a corresponding analytics engine starts operation when a client subscribes directly or indirectly for events produced by the analytics or rule engine or when a client requests the corresponding scene description stream. An analytics module must be attached to a Video source using the media profiles before it can be used. In case differing analytics configurations are attached to the same profile it is undefined which of the analytics module configuration becomes active if no stream is activated or multiple streams with different profiles are activated at the same time."
+								"description": "Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.\n\nAlthough this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and Media2AnalyticsConfigurations.\n\nThe device shall ensure that a corresponding analytics engine starts operation when a client subscribes directly or indirectly for events produced by the analytics or rule engine or when a client requests the corresponding scene description stream. An analytics module must be attached to a Video source using the media profiles before it can be used. In case differing analytics configurations are attached to the same profile it is undefined which of the analytics module configuration becomes active if no stream is activated or multiple streams with different profiles are activated at the same time."
 							},
 							"response": [
 								{
@@ -7180,12 +7270,12 @@
 					"name": "Rules",
 					"item": [
 						{
-							"name": "SupportedRules",
+							"name": "AnalyticsSupportedRules",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7200,7 +7290,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"SupportedRules"
+										"AnalyticsSupportedRules"
 									],
 									"query": [
 										{
@@ -7213,12 +7303,12 @@
 							},
 							"response": [
 								{
-									"name": "SupportedRules",
+									"name": "AnalyticsSupportedRules",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7233,7 +7323,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"SupportedRules"
+												"AnalyticsSupportedRules"
 											],
 											"query": [
 												{
@@ -7265,7 +7355,7 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"4694424b-74bb-45ee-a014-ebb6d09855f9\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"SupportedRules\",\n        \"origin\": 1665460098832568388,\n        \"readings\": [\n            {\n                \"id\": \"155dc49e-caa7-492c-be74-0cf150ca2302\",\n                \"origin\": 1665460098832568388,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"SupportedRules\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"SupportedRules\": {\n                        \"RuleContentSchemaLocation\": \"http://www.w3.org/2001/XMLSchema\",\n                        \"RuleDescription\": [\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 10,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"IsMotion\",\n                                                \"Type\": \"xs:boolean\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/CellMotionDetector/Motion\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSourceConfigurationToken\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"VideoAnalyticsConfigurationToken\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:CellMotionDetector\",\n                                \"Parameters\": {\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"MinCount\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"AlarmOnDelay\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"AlarmOffDelay\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"ActiveCells\",\n                                            \"Type\": \"xs:base64Binary\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 10,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"State\",\n                                                \"Type\": \"xs:boolean\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/MotionRegionDetector/Motion\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"RuleName\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:MotionRegionDetector\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"MotionRegion\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"ElementItemDescription\": [\n                                            {\n                                                \"Name\": \"Image\"\n                                            },\n                                            {\n                                                \"Name\": \"BoundingBox\"\n                                            }\n                                        ],\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Likelihood\",\n                                                \"Type\": \"xs:float\"\n                                            },\n                                            {\n                                                \"Name\": \"Label\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"ImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            },\n                                            {\n                                                \"Name\": \"EnrollmentID\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"RefImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/Recognition/Face\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:FaceRecognition\",\n                                \"Parameters\": {\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"IncludeImage\",\n                                            \"Type\": \"xs:string\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"ElementItemDescription\": [\n                                            {\n                                                \"Name\": \"BoundingBox\"\n                                            },\n                                            {\n                                                \"Name\": \"Image\"\n                                            },\n                                            {\n                                                \"Name\": \"LicensePlateInfo\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleInfo\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleImage\"\n                                            }\n                                        ],\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Likelihood\",\n                                                \"Type\": \"xs:float\"\n                                            },\n                                            {\n                                                \"Name\": \"Label\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"ImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleImageURI\",\n                                                \"Type\": \"xs:anyURI\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/Recognition/LicensePlate\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:LicensePlateRecognition\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"Region\"\n                                        },\n                                        {\n                                            \"Name\": \"SnapLine\"\n                                        }\n                                    ],\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"IncludeImage\",\n                                            \"Type\": \"xs:string\"\n                                        },\n                                        {\n                                            \"Name\": \"PlateLocation\",\n                                            \"Type\": \"xs:string\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Count\",\n                                                \"Type\": \"xs:int\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/CountAggregation/Counter\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:LineCounting\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"Segments\"\n                                        }\n                                    ],\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"ReportTimeInterval\",\n                                            \"Type\": \"xs:duration\"\n                                        },\n                                        {\n                                            \"Name\": \"ResetTime\",\n                                            \"Type\": \"xs:time\"\n                                        },\n                                        {\n                                            \"Name\": \"Direction\",\n                                            \"Type\": \"tt:Direction\"\n                                        },\n                                        {\n                                            \"Name\": \"PassAllPolylines\",\n                                            \"Type\": \"xs:boolean\"\n                                        }\n                                    ]\n                                }\n                            }\n                        ]\n                    }\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"4694424b-74bb-45ee-a014-ebb6d09855f9\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"AnalyticsSupportedRules\",\n        \"origin\": 1665460098832568388,\n        \"readings\": [\n            {\n                \"id\": \"155dc49e-caa7-492c-be74-0cf150ca2302\",\n                \"origin\": 1665460098832568388,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"AnalyticsSupportedRules\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"SupportedRules\": {\n                        \"RuleContentSchemaLocation\": \"http://www.w3.org/2001/XMLSchema\",\n                        \"RuleDescription\": [\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 10,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"IsMotion\",\n                                                \"Type\": \"xs:boolean\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/CellMotionDetector/Motion\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSourceConfigurationToken\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"VideoAnalyticsConfigurationToken\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:CellMotionDetector\",\n                                \"Parameters\": {\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"MinCount\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"AlarmOnDelay\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"AlarmOffDelay\",\n                                            \"Type\": \"xs:integer\"\n                                        },\n                                        {\n                                            \"Name\": \"ActiveCells\",\n                                            \"Type\": \"xs:base64Binary\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 10,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"State\",\n                                                \"Type\": \"xs:boolean\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/MotionRegionDetector/Motion\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"RuleName\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:MotionRegionDetector\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"MotionRegion\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"ElementItemDescription\": [\n                                            {\n                                                \"Name\": \"Image\"\n                                            },\n                                            {\n                                                \"Name\": \"BoundingBox\"\n                                            }\n                                        ],\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Likelihood\",\n                                                \"Type\": \"xs:float\"\n                                            },\n                                            {\n                                                \"Name\": \"Label\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"ImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            },\n                                            {\n                                                \"Name\": \"EnrollmentID\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"RefImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/Recognition/Face\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:FaceRecognition\",\n                                \"Parameters\": {\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"IncludeImage\",\n                                            \"Type\": \"xs:string\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"ElementItemDescription\": [\n                                            {\n                                                \"Name\": \"BoundingBox\"\n                                            },\n                                            {\n                                                \"Name\": \"Image\"\n                                            },\n                                            {\n                                                \"Name\": \"LicensePlateInfo\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleInfo\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleImage\"\n                                            }\n                                        ],\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Likelihood\",\n                                                \"Type\": \"xs:float\"\n                                            },\n                                            {\n                                                \"Name\": \"Label\",\n                                                \"Type\": \"xs:string\"\n                                            },\n                                            {\n                                                \"Name\": \"ImageUri\",\n                                                \"Type\": \"xs:anyURI\"\n                                            },\n                                            {\n                                                \"Name\": \"VehicleImageURI\",\n                                                \"Type\": \"xs:anyURI\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/Recognition/LicensePlate\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:LicensePlateRecognition\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"Region\"\n                                        },\n                                        {\n                                            \"Name\": \"SnapLine\"\n                                        }\n                                    ],\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"IncludeImage\",\n                                            \"Type\": \"xs:string\"\n                                        },\n                                        {\n                                            \"Name\": \"PlateLocation\",\n                                            \"Type\": \"xs:string\"\n                                        }\n                                    ]\n                                }\n                            },\n                            {\n                                \"Fixed\": false,\n                                \"MaxInstances\": 1,\n                                \"Messages\": {\n                                    \"Data\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"Count\",\n                                                \"Type\": \"xs:int\"\n                                            }\n                                        ]\n                                    },\n                                    \"IsProperty\": true,\n                                    \"ParentTopic\": \"tns1:RuleEngine/CountAggregation/Counter\",\n                                    \"Source\": {\n                                        \"SimpleItemDescription\": [\n                                            {\n                                                \"Name\": \"VideoSource\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"AnalyticsConfiguration\",\n                                                \"Type\": \"tt:ReferenceToken\"\n                                            },\n                                            {\n                                                \"Name\": \"Rule\",\n                                                \"Type\": \"xs:string\"\n                                            }\n                                        ]\n                                    }\n                                },\n                                \"Name\": \"tt:LineCounting\",\n                                \"Parameters\": {\n                                    \"ElementItemDescription\": [\n                                        {\n                                            \"Name\": \"Segments\"\n                                        }\n                                    ],\n                                    \"SimpleItemDescription\": [\n                                        {\n                                            \"Name\": \"ReportTimeInterval\",\n                                            \"Type\": \"xs:duration\"\n                                        },\n                                        {\n                                            \"Name\": \"ResetTime\",\n                                            \"Type\": \"xs:time\"\n                                        },\n                                        {\n                                            \"Name\": \"Direction\",\n                                            \"Type\": \"tt:Direction\"\n                                        },\n                                        {\n                                            \"Name\": \"PassAllPolylines\",\n                                            \"Type\": \"xs:boolean\"\n                                        }\n                                    ]\n                                }\n                            }\n                        ]\n                    }\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
@@ -7275,7 +7365,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Rules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7290,7 +7380,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Rules"
+										"AnalyticsRules"
 									],
 									"query": [
 										{
@@ -7308,7 +7398,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Rules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7323,7 +7413,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Rules"
+												"AnalyticsRules"
 											],
 											"query": [
 												{
@@ -7355,17 +7445,17 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"16f84c82-ee09-41bb-a012-27b46cff27fe\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"Rules\",\n        \"origin\": 1665460089922943960,\n        \"readings\": [\n            {\n                \"id\": \"2f46e1f1-6f39-449a-bd68-6387db6a1008\",\n                \"origin\": 1665460089922943960,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"Rules\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Rule\": [\n                        {\n                            \"Name\": \"MyMotionDetectorRule\",\n                            \"Parameters\": {\n                                \"SimpleItem\": [\n                                    {\n                                        \"Name\": \"MinCount\",\n                                        \"Value\": \"5\"\n                                    },\n                                    {\n                                        \"Name\": \"AlarmOnDelay\",\n                                        \"Value\": \"1000\"\n                                    },\n                                    {\n                                        \"Name\": \"AlarmOffDelay\",\n                                        \"Value\": \"1000\"\n                                    },\n                                    {\n                                        \"Name\": \"ActiveCells\",\n                                        \"Value\": \"zwA=\"\n                                    }\n                                ]\n                            },\n                            \"Type\": \"tt:CellMotionDetector\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"16f84c82-ee09-41bb-a012-27b46cff27fe\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"AnalyticsRules\",\n        \"origin\": 1665460089922943960,\n        \"readings\": [\n            {\n                \"id\": \"2f46e1f1-6f39-449a-bd68-6387db6a1008\",\n                \"origin\": 1665460089922943960,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"AnalyticsRules\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Rule\": [\n                        {\n                            \"Name\": \"MyMotionDetectorRule\",\n                            \"Parameters\": {\n                                \"SimpleItem\": [\n                                    {\n                                        \"Name\": \"MinCount\",\n                                        \"Value\": \"5\"\n                                    },\n                                    {\n                                        \"Name\": \"AlarmOnDelay\",\n                                        \"Value\": \"1000\"\n                                    },\n                                    {\n                                        \"Name\": \"AlarmOffDelay\",\n                                        \"Value\": \"1000\"\n                                    },\n                                    {\n                                        \"Name\": \"ActiveCells\",\n                                        \"Value\": \"zwA=\"\n                                    }\n                                ]\n                            },\n                            \"Type\": \"tt:CellMotionDetector\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "RuleOptions",
+							"name": "AnalyticsRuleOptions",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7380,7 +7470,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"RuleOptions"
+										"AnalyticsRuleOptions"
 									],
 									"query": [
 										{
@@ -7393,12 +7483,12 @@
 							},
 							"response": [
 								{
-									"name": "RuleOptions",
+									"name": "AnalyticsRuleOptions",
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7413,7 +7503,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"RuleOptions"
+												"AnalyticsRuleOptions"
 											],
 											"query": [
 												{
@@ -7445,18 +7535,18 @@
 										}
 									],
 									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"bf7a5fc7-7523-4690-87b7-273b2a373ed3\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"RuleOptions\",\n        \"origin\": 1665460126357157536,\n        \"readings\": [\n            {\n                \"id\": \"2bdd1ff4-7d2a-441b-bbc3-dfa50c27b096\",\n                \"origin\": 1665460126357157536,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"RuleOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"RuleOptions\": [\n                        {\n                            \"MotionRegionConfigOptions\": {\n                                \"DisarmSupport\": false,\n                                \"PolygonLimits\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                },\n                                \"PolygonSupport\": false\n                            },\n                            \"Name\": \"MotionRegion\",\n                            \"Type\": \"axt:MotionRegionConfigOptions\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"bf7a5fc7-7523-4690-87b7-273b2a373ed3\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"AnalyticsRuleOptions\",\n        \"origin\": 1665460126357157536,\n        \"readings\": [\n            {\n                \"id\": \"2bdd1ff4-7d2a-441b-bbc3-dfa50c27b096\",\n                \"origin\": 1665460126357157536,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"AnalyticsRuleOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"RuleOptions\": [\n                        {\n                            \"MotionRegionConfigOptions\": {\n                                \"DisarmSupport\": false,\n                                \"PolygonLimits\": {\n                                    \"Max\": 0,\n                                    \"Min\": 0\n                                },\n                                \"PolygonSupport\": false\n                            },\n                            \"Name\": \"MotionRegion\",\n                            \"Type\": \"axt:MotionRegionConfigOptions\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
 						},
 						{
-							"name": "CreateRules",
+							"name": "AnalyticsCreateRules",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"CreateRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"Object Counting\",\n                \"Type\": \"tt:LineCounting\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"Armed\",\n                            \"Value\": \"true\"\n                        }\n                    ],\n                    \"ElementItem\": [\n                        {\n                            \"Name\": \"Segments\",\n                            \"Polyline\": {\n                                \"Point\": [\n                                    {\n                                        \"x\": \"0.16\",\n                                        \"y\": \"0.5\"\n                                    },\n                                    {\n                                        \"x\": \"0.16\",\n                                        \"y\": \"-0.5\"\n                                    }\n                                ]\n                            }\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
+									"raw": "{\n    \"AnalyticsCreateRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"Object Counting\",\n                \"Type\": \"tt:LineCounting\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"Armed\",\n                            \"Value\": \"true\"\n                        }\n                    ],\n                    \"ElementItem\": [\n                        {\n                            \"Name\": \"Segments\",\n                            \"Polyline\": {\n                                \"Point\": [\n                                    {\n                                        \"x\": \"0.16\",\n                                        \"y\": \"0.5\"\n                                    },\n                                    {\n                                        \"x\": \"0.16\",\n                                        \"y\": \"-0.5\"\n                                    }\n                                ]\n                            }\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7464,7 +7554,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateRules",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7479,20 +7569,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"CreateRules"
+										"AnalyticsCreateRules"
 									]
 								},
-								"description": "Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedRules, where the Name of the supported rule correspond to the type of an rule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.\n\nAlthough this method is mandatory a device implementation must not support adding rules. Instead it can provide a fixed set of predefined configurations via the media service function GetCompatibleVideoAnalyticsConfigurations."
+								"description": "Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via AnalyticsSupportedRules, where the Name of the supported rule correspond to the type of an rule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.\n\nAlthough this method is mandatory a device implementation must not support adding rules. Instead it can provide a fixed set of predefined configurations via the media service function GetCompatibleVideoAnalyticsConfigurations."
 							},
 							"response": [
 								{
-									"name": "CreateRules",
+									"name": "AnalyticsCreateRules",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"CreateRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"Object Counting\",\n                \"Type\": \"tt:LineCounting\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"Armed\", \n                            \"Value\":\"true\"\n                        }\n                    ],\n                    \"ElementItem\": [\n                        {\n                            \"Name\":\"Segments\", \n                            \"Polyline\": {\n                                \"Point\": [\n                                    {\n                                        \"x\":\"0.16\",\n                                        \"y\": \"0.5\"\n                                    },\n                                    {\n                                        \"x\":\"0.16\",\n                                        \"y\": \"-0.5\"\n                                    }\n                                ]\n                            }\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
+											"raw": "{\n    \"AnalyticsCreateRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"Object Counting\",\n                \"Type\": \"tt:LineCounting\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"Armed\", \n                            \"Value\":\"true\"\n                        }\n                    ],\n                    \"ElementItem\": [\n                        {\n                            \"Name\":\"Segments\", \n                            \"Polyline\": {\n                                \"Point\": [\n                                    {\n                                        \"x\":\"0.16\",\n                                        \"y\": \"0.5\"\n                                    },\n                                    {\n                                        \"x\":\"0.16\",\n                                        \"y\": \"-0.5\"\n                                    }\n                                ]\n                            }\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -7500,7 +7590,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateRules",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7515,7 +7605,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"CreateRules"
+												"AnalyticsCreateRules"
 											]
 										}
 									},
@@ -7546,13 +7636,13 @@
 							]
 						},
 						{
-							"name": "DeleteRules",
+							"name": "AnalyticsDeleteRules",
 							"request": {
 								"method": "PUT",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"DeleteRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"RuleName\": [\n            \"Object Counting\"\n        ]\n    }\n}",
+									"raw": "{\n    \"AnalyticsDeleteRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"RuleName\": [\n            \"Object Counting\"\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7560,7 +7650,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteRules",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7575,20 +7665,20 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"DeleteRules"
+										"AnalyticsDeleteRules"
 									]
 								},
 								"description": "Remove one or more rules from a VideoAnalyticsConfiguration."
 							},
 							"response": [
 								{
-									"name": "DeleteRules",
+									"name": "AnalyticsDeleteRules",
 									"originalRequest": {
 										"method": "PUT",
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"DeleteRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"RuleName\": [\n            \"Object Counting\"\n        ]\n    }\n}",
+											"raw": "{\n    \"AnalyticsDeleteRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"RuleName\": [\n            \"Object Counting\"\n        ]\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -7596,7 +7686,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteRules",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7611,7 +7701,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"DeleteRules"
+												"AnalyticsDeleteRules"
 											]
 										}
 									},
@@ -7648,7 +7738,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"Rules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"ClassFilter\",\n                            \"Value\": \" Bike Car Truck\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
+									"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"ClassFilter\",\n                            \"Value\": \" Bike Car Truck\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -7656,7 +7746,7 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Rules",
+									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
 									"protocol": "http",
 									"host": [
 										"0",
@@ -7671,7 +7761,7 @@
 										"device",
 										"name",
 										"{{EDGEX_DEVICE_NAME}}",
-										"Rules"
+										"AnalyticsRules"
 									]
 								},
 								"description": "Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names."
@@ -7684,7 +7774,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"Rules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"ClassFilter\", \n                            \"Value\":\" Bike Car Truck\"\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
+											"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"ClassFilter\", \n                            \"Value\":\" Bike Car Truck\"\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -7692,7 +7782,7 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Rules",
+											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
 											"protocol": "http",
 											"host": [
 												"0",
@@ -7707,7 +7797,7 @@
 												"device",
 												"name",
 												"{{EDGEX_DEVICE_NAME}}",
-												"Rules"
+												"AnalyticsRules"
 											]
 										}
 									},

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "82c027e5-c2a9-4366-8d6d-2b4caf0d9690",
+		"_postman_id": "8642c9c1-2ab8-48cc-84f2-ac4bcc1a1a46",
 		"name": "device-onvif-camera",
 		"description": "The Open Network Video Interface Forum (ONVIF) Device Service is a microservice created to address the lack of standardization and automation of camera discovery and onboarding. EdgeX Foundry is a flexible microservice-based architecture created to promote the interoperability of multiple device interface combinations at the edge. In an EdgeX deployment, the ONVIF Device Service controls and communicates with ONVIF-compliant cameras, while EdgeX Foundry presents a standard interface to application developers. With normalized connectivity protocols and a vendor-neutral architecture, EdgeX paired with ONVIF Camera Device Service, simplifies deployment of edge camera devices.\n\nUse the ONVIF Device Service to streamline and scale your edge camera device deployment.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -390,7 +390,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryMode"
 							]
-						}},
+						}
+					},
 					"response": [
 						{
 							"name": "GetDiscoveryMode",
@@ -626,7 +627,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryScopes"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "DiscoveryScopes",
@@ -701,7 +703,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryScopes"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Put DiscoveryScopes",
@@ -785,7 +788,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"RemoveDiscoveryScopes"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Remove DiscoveryScopes",
@@ -887,7 +891,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Hostname"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Hostname",
@@ -962,7 +967,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Hostname"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetHostname",
@@ -1049,7 +1055,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DNS"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "DNS",
@@ -1124,7 +1131,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DNS"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetDNS",
@@ -1199,7 +1207,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkInterfaces"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "NetworkInterfaces",
@@ -1274,7 +1283,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkInterfaces"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetNetworkInterfaces",
@@ -1349,7 +1359,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkProtocols"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "NetworkProtocols",
@@ -1424,7 +1435,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkProtocols"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetNetworkProtocols",
@@ -1511,7 +1523,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkDefaultGateway"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "NetworkDefaultGateway",
@@ -1586,7 +1599,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkDefaultGateway"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetNetworkDefaultGateway",
@@ -1912,7 +1926,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemDateAndTime"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SystemDateAndTime",
@@ -1987,7 +2002,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemDateAndTime"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetSystemDateAndTime",
@@ -2059,7 +2075,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemFactoryDefault"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SystemFactoryDefault",
@@ -2293,7 +2310,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Users"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Users",
@@ -2368,7 +2386,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Users"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Users",
@@ -2452,7 +2471,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"CreateUsers"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Create Users",
@@ -2525,7 +2545,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DeleteUsers"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "Delete users",
@@ -2605,7 +2626,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MetadataConfigurations"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "MetadataConfigurations",
@@ -2677,7 +2699,8 @@
 									"value": "{{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}"
 								}
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "GetMetadataConfiguration",
@@ -2758,7 +2781,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MetadataConfiguration"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetMetadataConfiguration",
@@ -2839,7 +2863,8 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
 								}
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "GetCompatibleMetadataConfigurations",
@@ -2917,7 +2942,8 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}"
 								}
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "GetMetadataConfigurationOptions",
@@ -2998,7 +3024,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"AddMetadataConfiguration"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "AddMetadataConfiguration",
@@ -3082,7 +3109,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"RemoveMetadataConfiguration"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "RemoveMetadataConfiguration",
@@ -3174,7 +3202,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MediaProfiles"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "MediaProfiles",
@@ -3496,7 +3525,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"VideoEncoderConfigurations"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "VideoEncoderConfigurations",
@@ -3568,7 +3598,8 @@
 									"value": "{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}"
 								}
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "VideoEncoderConfiguration",
@@ -3649,7 +3680,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"VideoEncoderConfiguration"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "SetVideoEncoderConfiguration",
@@ -3730,7 +3762,8 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}"
 								}
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "VideoEncoderConfigurationOptions",
@@ -4152,7 +4185,8 @@
 											"description": "{\"ConfigurationToken\": \"PTZConfiguration0\"}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZConfigurationOptions",
@@ -4234,7 +4268,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZConfiguration"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "SetConfiguration",
@@ -4318,7 +4353,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AddPTZConfiguration"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AddPTZConfiguration",
@@ -4402,7 +4438,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"RemovePTZConfiguration"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "RemovePTZConfiguration",
@@ -4491,7 +4528,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZAbsoluteMove"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZAbsoluteMove",
@@ -4575,7 +4613,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZRelativeMove"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZRelativeMove",
@@ -4659,7 +4698,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZContinuousMove"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZContinuousMove",
@@ -4753,7 +4793,8 @@
 											"description": "{\"ProfileToken\":\"profile_1\"}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZStatus",
@@ -4834,7 +4875,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZStop"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZStop",
@@ -4923,7 +4965,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZPreset"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "SetPreset",
@@ -5004,7 +5047,8 @@
 											"value": "{{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZPresets",
@@ -5085,7 +5129,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZGotoPreset"
 									]
-								}							},
+								}
+							},
 							"response": []
 						},
 						{
@@ -5115,7 +5160,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZRemovePreset"
 									]
-								}							},
+								}
+							},
 							"response": []
 						}
 					]
@@ -5236,7 +5282,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZHomePosition"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "PTZHomePosition",
@@ -5409,7 +5456,8 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"EventProperties"
 							]
-						}					},
+						}
+					},
 					"response": [
 						{
 							"name": "EventProperties",
@@ -5741,7 +5789,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2Profiles"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "GetMedia2Profiles",
@@ -5807,7 +5856,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2AnalyticsConfigurations"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "Media2AnalyticsConfigurations",
@@ -5882,7 +5932,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2AddConfiguration"
 									]
-								}							},
+								}
+							},
 							"response": []
 						},
 						{
@@ -5912,7 +5963,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2RemoveConfiguration"
 									]
-								}							},
+								}
+							},
 							"response": []
 						}
 					]
@@ -5938,7 +5990,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"SupportedAnalyticsModules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "SupportedAnalyticsModules",
@@ -6010,7 +6063,8 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "GetAnalyticsModules",
@@ -6091,7 +6145,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsModules"
 									]
-								}							},
+								}
+							},
 							"response": []
 						},
 						{
@@ -6121,7 +6176,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"CreateAnalyticsModules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "CreateAnalyticsModules",
@@ -6205,7 +6261,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"DeleteAnalyticsModules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "DeleteAnalyticsModules",
@@ -6286,7 +6343,8 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AnalyticsModuleOptions",
@@ -6369,7 +6427,8 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AnalyticsSupportedRules",
@@ -6447,7 +6506,8 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "GetRules",
@@ -6528,7 +6588,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsRules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "ModifyRules",
@@ -6609,7 +6670,8 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AnalyticsRuleOptions",
@@ -6690,7 +6752,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsCreateRules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AnalyticsCreateRules",
@@ -6774,7 +6837,8 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsDeleteRules"
 									]
-								}							},
+								}
+							},
 							"response": [
 								{
 									"name": "AnalyticsDeleteRules",

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "79e5804a-2979-4157-9973-8d25ad33986d",
+		"_postman_id": "82c027e5-c2a9-4366-8d6d-2b4caf0d9690",
 		"name": "device-onvif-camera",
 		"description": "The Open Network Video Interface Forum (ONVIF) Device Service is a microservice created to address the lack of standardization and automation of camera discovery and onboarding. EdgeX Foundry is a flexible microservice-based architecture created to promote the interoperability of multiple device interface combinations at the edge. In an EdgeX deployment, the ONVIF Device Service controls and communicates with ONVIF-compliant cameras, while EdgeX Foundry presents a standard interface to application developers. With normalized connectivity protocols and a vendor-neutral architecture, EdgeX paired with ONVIF Camera Device Service, simplifies deployment of edge camera devices.\n\nUse the ONVIF Device Service to streamline and scale your edge camera device deployment.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -16,15 +16,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Capabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Capabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -42,15 +37,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Capabilities",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Capabilities",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -93,15 +83,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceCapabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceCapabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -119,15 +104,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceCapabilities",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceCapabilities",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -170,15 +150,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaCapabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaCapabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -196,15 +171,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaCapabilities",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaCapabilities",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -247,15 +217,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZCapabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZCapabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -273,15 +238,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZCapabilities",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZCapabilities",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -324,15 +284,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ImagingCapabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/ImagingCapabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -351,15 +306,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventCapabilities",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventCapabilities",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -377,15 +327,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventCapabilities",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventCapabilities",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -428,20 +373,15 @@
 			"name": "Auto Discovery",
 			"item": [
 				{
-					"name": "GetDiscoveryMode",
+					"name": "DiscoveryMode",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -450,9 +390,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryMode"
 							]
-						},
-						"description": "This operation gets the discovery mode of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support retrieval of the discovery mode setting through the GetDiscoveryMode command."
-					},
+						}},
 					"response": [
 						{
 							"name": "GetDiscoveryMode",
@@ -460,15 +398,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -506,7 +439,7 @@
 					]
 				},
 				{
-					"name": "Set DiscoveryMode",
+					"name": "DiscoveryMode",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -520,15 +453,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -537,12 +465,11 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryMode"
 							]
-						},
-						"description": "This operation sets the discovery mode operation of a device. See Section 7.2 for the definition of the different device discovery modes. The device shall support configuration of the discovery mode setting through the SetDiscoveryMode command."
+						}
 					},
 					"response": [
 						{
-							"name": "Set DiscoveryMode",
+							"name": "DiscoveryMode",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
@@ -556,15 +483,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryMode",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -602,7 +524,7 @@
 					]
 				},
 				{
-					"name": "Add Discovery Scopes",
+					"name": "AddDiscoveryScopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -616,15 +538,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -633,8 +550,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"AddDiscoveryScopes"
 							]
-						},
-						"description": "This operation adds new configurable scope parameters to a device. The scope parameters are used in the device discovery to match a probe message. The device shall support addition of discovery scope parameters through the AddScopes command."
+						}
 					},
 					"response": [
 						{
@@ -652,15 +568,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddDiscoveryScopes",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -698,20 +609,15 @@
 					]
 				},
 				{
-					"name": "Get DiscoveryScopes",
+					"name": "DiscoveryScopes",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -720,25 +626,18 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryScopes"
 							]
-						},
-						"description": "This operation requests the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The Scope parameters are of two different types:  \n\\- Fixed  \n\\- Configurable  \nFixed scope parameters are permanent device characteristics and cannot be removed through the device management interface. The scope type is indicated in the scope list returned in the get scope parameters response. A device shall support retrieval of discovery scope parameters through the GetScopes command. As some scope parameters are mandatory, the device shall return a non-empty scope list in the response."
-					},
+						}					},
 					"response": [
 						{
-							"name": "Get DiscoveryScopes",
+							"name": "DiscoveryScopes",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -776,7 +675,7 @@
 					]
 				},
 				{
-					"name": "Put DiscoveryScopes",
+					"name": "DiscoveryScopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -790,15 +689,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -807,9 +701,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DiscoveryScopes"
 							]
-						},
-						"description": "This operation sets the scope parameters of a device. The scope parameters are used in the device discovery to match a probe message. This operation replaces all existing configurable scope parameters (not fixed parameters). If this shall be avoided, one should use the scope add command instead."
-					},
+						}					},
 					"response": [
 						{
 							"name": "Put DiscoveryScopes",
@@ -826,15 +718,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DiscoveryScopes",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -872,7 +759,7 @@
 					]
 				},
 				{
-					"name": "Remove DiscoveryScopes",
+					"name": "RemoveDiscoveryScopes",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -886,15 +773,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -903,9 +785,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"RemoveDiscoveryScopes"
 							]
-						},
-						"description": "This operation deletes scope-configurable scope parameters from a device. The scope parameters are used in the device discovery to match a probe message, see Section 7. The device shall support deletion of discovery scope parameters through the RemoveScopes command"
-					},
+						}					},
 					"response": [
 						{
 							"name": "Remove DiscoveryScopes",
@@ -922,15 +802,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveDiscoveryScopes",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -973,15 +848,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EndpointReference",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EndpointReference",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1005,15 +875,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1022,9 +887,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Hostname"
 							]
-						},
-						"description": "This operation is used by an endpoint to get the hostname from a device. The device shall return its hostname configurations through the GetHostname command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "Hostname",
@@ -1032,15 +895,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1078,7 +936,7 @@
 					]
 				},
 				{
-					"name": "SetHostname",
+					"name": "Hostname",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1092,15 +950,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1109,9 +962,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Hostname"
 							]
-						},
-						"description": "This operation sets the hostname on a device. It shall be possible to set the device hostname configurations through the SetHostname command.  \nA device shall accept string formatted according to RFC 1123 section 2.1 or alternatively to RFC 952, other string shall be considered as invalid strings."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetHostname",
@@ -1128,15 +979,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Hostname",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1191,15 +1037,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1208,9 +1049,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DNS"
 							]
-						},
-						"description": "This operation gets the DNS settings from a device. The device shall return its DNS configurations through the GetDNS command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "DNS",
@@ -1218,15 +1057,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1264,7 +1098,7 @@
 					]
 				},
 				{
-					"name": "SetDNS",
+					"name": "DNS",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1278,15 +1112,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1295,9 +1124,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DNS"
 							]
-						},
-						"description": "This operation sets the DNS settings on a device. It shall be possible to set the device DNS configurations through the SetDNS command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetDNS",
@@ -1314,15 +1141,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DNS",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1365,15 +1187,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1382,9 +1199,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkInterfaces"
 							]
-						},
-						"description": "This operation gets the network interface configuration from a device. The device shall support return of network interface configuration settings as defined by the NetworkInterface type through the GetNetworkInterfaces command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "NetworkInterfaces",
@@ -1392,15 +1207,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1438,7 +1248,7 @@
 					]
 				},
 				{
-					"name": "SetNetworkInterfaces",
+					"name": "NetworkInterfaces",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1452,15 +1262,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1469,9 +1274,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkInterfaces"
 							]
-						},
-						"description": "This operation sets the network interface configuration on a device. The device shall support network configuration of supported network interfaces through the SetNetworkInterfaces command.\n\nFor interoperability with a client unaware of the IEEE 802.11 extension a device shall retain its IEEE 802.11 configuration if the IEEE 802.11 configuration element isn’t present in the request."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetNetworkInterfaces",
@@ -1488,15 +1291,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkInterfaces",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1539,15 +1337,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1556,9 +1349,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkProtocols"
 							]
-						},
-						"description": "This operation gets defined network protocols from a device. The device shall support the GetNetworkProtocols command returning configured network protocols."
-					},
+						}					},
 					"response": [
 						{
 							"name": "NetworkProtocols",
@@ -1566,15 +1357,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1612,7 +1398,7 @@
 					]
 				},
 				{
-					"name": "SetNetworkProtocols",
+					"name": "NetworkProtocols",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1626,15 +1412,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1643,9 +1424,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkProtocols"
 							]
-						},
-						"description": "This operation configures defined network protocols on a device. The device shall support configuration of defined network protocols through the SetNetworkProtocols command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetNetworkProtocols",
@@ -1662,15 +1441,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkProtocols",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1725,15 +1499,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1742,9 +1511,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkDefaultGateway"
 							]
-						},
-						"description": "This operation gets the default gateway settings from a device. The device shall support the GetNetworkDefaultGateway command returning configured default gateway address(es)."
-					},
+						}					},
 					"response": [
 						{
 							"name": "NetworkDefaultGateway",
@@ -1752,15 +1519,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1798,7 +1560,7 @@
 					]
 				},
 				{
-					"name": "SetNetworkDefaultGateway",
+					"name": "NetworkDefaultGateway",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1812,15 +1574,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1829,9 +1586,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"NetworkDefaultGateway"
 							]
-						},
-						"description": "This operation sets the default gateway settings on a device. The device shall support configuration of default gateway through the SetNetworkDefaultGateway command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetNetworkDefaultGateway",
@@ -1848,15 +1603,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkDefaultGateway",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1911,15 +1661,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -1938,15 +1683,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -1984,7 +1724,7 @@
 					]
 				},
 				{
-					"name": "SetNetworkConfiguration",
+					"name": "NetworkConfiguration",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -1998,15 +1738,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2034,15 +1769,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/NetworkConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2091,15 +1821,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceInformation",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceInformation",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2108,8 +1833,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DeviceInformation"
 							]
-						},
-						"description": "This operation gets basic device information from the device."
+						}
 					},
 					"response": [
 						{
@@ -2118,15 +1842,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceInformation",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeviceInformation",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2181,15 +1900,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2198,9 +1912,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemDateAndTime"
 							]
-						},
-						"description": "This operation gets the device system date and time. The device shall support the return of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the GetSystemDateAndTime command.\n\nA device shall provide the UTCDateTime information."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SystemDateAndTime",
@@ -2208,15 +1920,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2254,7 +1961,7 @@
 					]
 				},
 				{
-					"name": "SetSystemDateAndTime",
+					"name": "SystemDateAndTime",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -2268,15 +1975,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2285,9 +1987,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemDateAndTime"
 							]
-						},
-						"description": "This operation sets the device system date and time. The device shall support the configuration of the daylight saving setting and of the manual system date and time (if applicable) or indication of NTP time (if applicable) through the SetSystemDateAndTime command.\n\nIf system time and date are set manually, the client shall include UTCDateTime in the request.\n\nA TimeZone token which is not formed according to the rules of IEEE 1003.1 section 8.3 is considered as invalid timezone.\n\nThe DayLightSavings flag should be set to true to activate any DST settings of the TimeZone string. Clear the DayLightSavings flag if the DST portion of the TimeZone settings should be ignored."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetSystemDateAndTime",
@@ -2304,15 +2004,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemDateAndTime",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2352,15 +2047,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemFactoryDefault",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemFactoryDefault",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2369,9 +2059,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"SystemFactoryDefault"
 							]
-						},
-						"description": "This operation reloads the parameters on the device to their factory default values."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SystemFactoryDefault",
@@ -2388,15 +2076,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemFactoryDefault",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemFactoryDefault",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2439,15 +2122,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RebootNeeded",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RebootNeeded",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2466,15 +2144,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RebootNeeded",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RebootNeeded",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2526,15 +2199,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemReboot",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemReboot",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2561,15 +2229,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemReboot",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SystemReboot",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2613,20 +2276,15 @@
 			"name": "User Handling",
 			"item": [
 				{
-					"name": "Get users",
+					"name": "Users",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2635,25 +2293,18 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"Users"
 							]
-						},
-						"description": "This operation lists the registered users and corresponding credentials on a device. The device shall support retrieval of registered device users and their credentials for the user token through the GetUsers command."
-					},
+						}					},
 					"response": [
 						{
-							"name": "Get users",
+							"name": "Users",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2691,7 +2342,91 @@
 					]
 				},
 				{
-					"name": "Create Users",
+					"name": "Users",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"Users\": {\n        \"User\": [\n            {\n                \"Username\": \"user1\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Administrator\"\n            },\n            {\n                \"Username\": \"user2\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Operator\"\n            }\n        ]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
+							"host": [
+								"{{CORE_COMMAND_URL}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"device",
+								"name",
+								"{{EDGEX_DEVICE_NAME}}",
+								"Users"
+							]
+						}					},
+					"response": [
+						{
+							"name": "Users",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"Users\": {\n        \"User\": [\n            {\n                \"Username\": \"user1\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Administrator\"\n            },\n            {\n                \"Username\": \"user2\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Operator\"\n            }\n        ]\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
+									"host": [
+										"{{CORE_COMMAND_URL}}"
+									],
+									"path": [
+										"api",
+										"v3",
+										"device",
+										"name",
+										"{{EDGEX_DEVICE_NAME}}",
+										"Users"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Correlation-Id",
+									"value": "bc42d5ca-4132-47e5-b159-98ca2aa1cdb8"
+								},
+								{
+									"key": "Date",
+									"value": "Sun, 25 Sep 2022 03:40:53 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "37"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200\n}"
+						}
+					]
+				},
+				{
+					"name": "CreateUsers",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -2705,15 +2440,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateUsers",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateUsers",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2722,9 +2452,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"CreateUsers"
 							]
-						},
-						"description": "This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user.\n\nONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper."
-					},
+						}					},
 					"response": [
 						{
 							"name": "Create Users",
@@ -2771,103 +2499,7 @@
 					]
 				},
 				{
-					"name": "Set users",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"Users\": {\n        \"User\": [\n            {\n                \"Username\": \"user1\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Administrator\"\n            },\n            {\n                \"Username\": \"user2\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Operator\"\n            }\n        ]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
-							"protocol": "http",
-							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
-							],
-							"port": "59882",
-							"path": [
-								"api",
-								"v3",
-								"device",
-								"name",
-								"{{EDGEX_DEVICE_NAME}}",
-								"Users"
-							]
-						},
-						"description": "This operation creates new device users and corresponding credentials on a device for authentication purposes. The device shall support creation of device users and their credentials through the CreateUsers command. Either all users are created successfully or a fault message shall be returned without creating any user.\n\nONVIF compliant devices are recommended to support password length of at least 28 bytes, as clients may follow the password derivation mechanism which results in 'password equivalent' of length 28 bytes, as described in section 3.1.2 of the ONVIF security white paper."
-					},
-					"response": [
-						{
-							"name": "Set users",
-							"originalRequest": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"Users\": {\n        \"User\": [\n            {\n                \"Username\": \"user1\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Administrator\"\n            },\n            {\n                \"Username\": \"user2\",\n                \"Password\": \"Password1!\",\n                \"UserLevel\": \"Operator\"\n            }\n        ]\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Users",
-									"protocol": "http",
-									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
-									],
-									"port": "59882",
-									"path": [
-										"api",
-										"v3",
-										"device",
-										"name",
-										"{{EDGEX_DEVICE_NAME}}",
-										"Users"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "X-Correlation-Id",
-									"value": "bc42d5ca-4132-47e5-b159-98ca2aa1cdb8"
-								},
-								{
-									"key": "Date",
-									"value": "Sun, 25 Sep 2022 03:40:53 GMT"
-								},
-								{
-									"key": "Content-Length",
-									"value": "37"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200\n}"
-						}
-					]
-				},
-				{
-					"name": "Delete users",
+					"name": "DeleteUsers",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -2881,15 +2513,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteUsers",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteUsers",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2898,9 +2525,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"DeleteUsers"
 							]
-						},
-						"description": "This operation deletes users on a device. The device shall support deletion of device users and their credentials through the DeleteUsers command. A device may have one or more fixed users that cannot be deleted to ensure access to the unit. Either all users are deleted successfully or a fault message shall be returned and no users be deleted."
-					},
+						}					},
 					"response": [
 						{
 							"name": "Delete users",
@@ -2917,15 +2542,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteUsers",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteUsers",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -2973,15 +2593,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurations",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurations",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -2990,9 +2605,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MetadataConfigurations"
 							]
-						},
-						"description": "This operation lists all existing metadata configurations. The client need not know anything apriori about the metadata in order to use the command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "MetadataConfigurations",
@@ -3000,15 +2613,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurations",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurations",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3051,15 +2659,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration?jsonObject={{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration?jsonObject={{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3074,9 +2677,7 @@
 									"value": "{{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}"
 								}
 							]
-						},
-						"description": "The GetMetadataConfiguration command fetches the metadata configuration if the metadata token is known."
-					},
+						}					},
 					"response": [
 						{
 							"name": "GetMetadataConfiguration",
@@ -3084,15 +2685,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration?jsonObject={{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration?jsonObject={{EDGEX_MEDIA_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3136,7 +2732,7 @@
 					]
 				},
 				{
-					"name": "SetMetadataConfiguration",
+					"name": "MetadataConfiguration",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -3150,15 +2746,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3167,9 +2758,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MetadataConfiguration"
 							]
-						},
-						"description": "This operation modifies a metadata configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be updated immediately according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected streams. NVC methods for changing a running stream are out of scope for this specification."
-					},
+						}					},
 					"response": [
 						{
 							"name": "SetMetadataConfiguration",
@@ -3186,15 +2775,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3237,15 +2821,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CompatibleMetadataConfigurations?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CompatibleMetadataConfigurations?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3260,9 +2839,7 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
 								}
 							]
-						},
-						"description": "This operation requests all the metadata configurations of the device that are compatible with a certain media profile. Each of the returned configurations shall be a valid input parameter for the AddMetadataConfiguration command on the media profile. The result varies depending on the capabilities, configurations and settings in the device."
-					},
+						}					},
 					"response": [
 						{
 							"name": "GetCompatibleMetadataConfigurations",
@@ -3270,15 +2847,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CompatibleMetadataConfigurations?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CompatibleMetadataConfigurations?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3327,15 +2899,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3350,9 +2917,7 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}"
 								}
 							]
-						},
-						"description": "This operation returns the available options (supported values and ranges for metadata configuration parameters) for changing the metadata configuration."
-					},
+						}					},
 					"response": [
 						{
 							"name": "GetMetadataConfigurationOptions",
@@ -3360,15 +2925,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MetadataConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_AND_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3426,15 +2986,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddMetadataConfiguration",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddMetadataConfiguration",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3443,9 +2998,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"AddMetadataConfiguration"
 							]
-						},
-						"description": "This operation adds a Metadata configuration to an existing media profile. If a configuration exists in the media profile, it will be replaced. The change shall be persistent. Adding a MetadataConfiguration to a Profile means that streams using that profile contain metadata. Metadata can consist of events, PTZ status, and/or video analytics data."
-					},
+						}					},
 					"response": [
 						{
 							"name": "AddMetadataConfiguration",
@@ -3462,15 +3015,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddMetadataConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddMetadataConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3522,15 +3070,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveMetadataConfiguration",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveMetadataConfiguration",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3539,9 +3082,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"RemoveMetadataConfiguration"
 							]
-						},
-						"description": "This operation removes a MetadataConfiguration from an existing media profile. If the media profile does not contain a MetadataConfiguration, the operation has no effect. The removal shall be persistent."
-					},
+						}					},
 					"response": [
 						{
 							"name": "RemoveMetadataConfiguration",
@@ -3558,15 +3099,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveMetadataConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemoveMetadataConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3626,15 +3162,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3643,9 +3174,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"MediaProfiles"
 							]
-						},
-						"description": "Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "MediaProfiles",
@@ -3653,15 +3182,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MediaProfiles",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3704,15 +3228,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/StreamUri?jsonObject={{EDGEX_MEDIA_PROFILE_STREAM_SETUP_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/StreamUri?jsonObject={{EDGEX_MEDIA_PROFILE_STREAM_SETUP_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3737,15 +3256,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/StreamUri?jsonObject={{EDGEX_MEDIA_PROFILE_STREAM_SETUP_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/StreamUri?jsonObject={{EDGEX_MEDIA_PROFILE_STREAM_SETUP_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3794,15 +3308,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3827,15 +3336,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Snapshot?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3884,15 +3388,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3916,15 +3415,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -3990,15 +3484,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurations",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurations",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -4007,9 +3496,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"VideoEncoderConfigurations"
 							]
-						},
-						"description": "This operation lists all existing video encoder configurations of a device. This command lists all configured video encoder configurations in a device. The client need not know anything apriori about the video encoder configurations in order to use the command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "VideoEncoderConfigurations",
@@ -4017,15 +3504,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurations",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurations",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4068,15 +3550,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration?jsonObject={{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration?jsonObject={{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -4091,9 +3568,7 @@
 									"value": "{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}"
 								}
 							]
-						},
-						"description": "If the video encoder configuration token is already known, the encoder configuration can be fetched through the GetVideoEncoderConfiguration command."
-					},
+						}					},
 					"response": [
 						{
 							"name": "VideoEncoderConfiguration",
@@ -4101,15 +3576,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration?jsonObject={{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration?jsonObject={{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4153,20 +3623,99 @@
 					]
 				},
 				{
+					"name": "VideoEncoderConfiguration",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"VideoEncoderConfiguration\": {\n        \"ForcePersistence\": false,\n        \"Configuration\": {\n            \"token\": \"{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN}}\",\n            \"Encoding\": \"H264\",\n            \"Quality\": 3.000000,\n            \"Resolution\": {\n                \"Width\": 1920,\n                \"Height\": 1080\n            },\n            \"Multicast\": {\n                \"Address\": {\n                    \"Type\": \"IPv4\",\n                    \"IPv4Address\": \"0.0.0.0\"\n                },\n                \"Port\": 8860,\n                \"TTL\": 1,\n                \"AutoStart\": false\n            }\n        }\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration",
+							"host": [
+								"{{CORE_COMMAND_URL}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"device",
+								"name",
+								"{{EDGEX_DEVICE_NAME}}",
+								"VideoEncoderConfiguration"
+							]
+						}					},
+					"response": [
+						{
+							"name": "SetVideoEncoderConfiguration",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"VideoEncoderConfiguration\": {\n        \"ForcePersistence\": false,\n        \"Configuration\":{\n            \"token\": \"{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN}}\",\n            \"Encoding\": \"H264\",\n            \"Quality\": 3.000000,\n            \"Resolution\": {\n                \"Width\": 1920,\n                \"Height\": 1080\n            },\n            \"Multicast\": {\n                \"Address\": {\n                    \"Type\": \"IPv4\",\n                    \"IPv4Address\": \"0.0.0.0\"\n                },\n                \"Port\": 8860,\n                \"TTL\": 1,\n                \"AutoStart\": false\n            }\n        }\n        \n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration",
+									"host": [
+										"{{CORE_COMMAND_URL}}"
+									],
+									"path": [
+										"api",
+										"v3",
+										"device",
+										"name",
+										"{{EDGEX_DEVICE_NAME}}",
+										"VideoEncoderConfiguration"
+									]
+								}
+							},
+							"status": "Internal Server Error",
+							"code": 500,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Correlation-Id",
+									"value": "8888c1a3-e632-4223-9013-41c5e938eb4d"
+								},
+								{
+									"key": "Date",
+									"value": "Fri, 05 Aug 2022 00:26:56 GMT"
+								},
+								{
+									"key": "Content-Length",
+									"value": "489"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"apiVersion\": \"v3\",\n    \"message\": \"request failed, status code: 500, err: {\\\"apiVersion\\\":\\\"v3\\\",\\\"message\\\":\\\"error writing DeviceResourece VideoEncoderConfiguration for TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4 -\\\\u003e failed to execute write command, \\\\u003cnil\\\\u003e -\\\\u003e invalid request for the function 'SetVideoEncoderConfiguration' of web service 'Media'. Onvif error: fault reason: , fault detail: , fault code: SOAP-ENV:Sender  \\\",\\\"statusCode\\\":500}\",\n    \"statusCode\": 500\n}"
+						}
+					]
+				},
+				{
 					"name": "VideoEncoderConfigurationOptions",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -4181,9 +3730,7 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}"
 								}
 							]
-						},
-						"description": "This operation returns the available options (supported values and ranges for video encoder configuration parameters) when the video encoder parameters are reconfigured.\n\nFor JPEG, MPEG4 and H264 extension elements have been defined that provide additional information. A device must provide the XxxOption information for all encodings supported and should additionally provide the corresponding XxxOption2 information.\n\nThis response contains the available video encoder configuration options. If a video encoder configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile. If no tokens are specified, the options shall be considered generic for the device."
-					},
+						}					},
 					"response": [
 						{
 							"name": "VideoEncoderConfigurationOptions",
@@ -4191,15 +3738,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfigurationOptions?jsonObject={{EDGEX_MEDIA_PROFILE_VIDEO_ENCODER_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4241,102 +3783,6 @@
 							"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"187b2e94-6efe-421f-b618-186a20fd41df\",\n        \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"VideoEncoderConfigurationOptions\",\n        \"origin\": 1659659212171416506,\n        \"readings\": [\n            {\n                \"id\": \"0b709715-f644-4cf0-a477-dcc3b5ef218c\",\n                \"origin\": 1659659212171416506,\n                \"deviceName\": \"TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4\",\n                \"resourceName\": \"VideoEncoderConfigurationOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Options\": {\n                        \"Extension\": {\n                            \"H264\": {\n                                \"BitrateRange\": {\n                                    \"Max\": 1024,\n                                    \"Min\": 256\n                                },\n                                \"EncodingIntervalRange\": {\n                                    \"Max\": 1,\n                                    \"Min\": 1\n                                },\n                                \"FrameRateRange\": {\n                                    \"Max\": 15,\n                                    \"Min\": 1\n                                },\n                                \"GovLengthRange\": {\n                                    \"Max\": 25,\n                                    \"Min\": 25\n                                },\n                                \"H264ProfilesSupported\": [\n                                    \"Main\"\n                                ],\n                                \"ResolutionsAvailable\": [\n                                    {\n                                        \"Height\": 1080,\n                                        \"Width\": 1920\n                                    },\n                                    {\n                                        \"Height\": 720,\n                                        \"Width\": 1280\n                                    },\n                                    {\n                                        \"Height\": 360,\n                                        \"Width\": 640\n                                    }\n                                ]\n                            }\n                        },\n                        \"H264\": {\n                            \"EncodingIntervalRange\": {\n                                \"Max\": 1,\n                                \"Min\": 1\n                            },\n                            \"FrameRateRange\": {\n                                \"Max\": 15,\n                                \"Min\": 1\n                            },\n                            \"GovLengthRange\": {\n                                \"Max\": 25,\n                                \"Min\": 25\n                            },\n                            \"H264ProfilesSupported\": [\n                                \"Main\"\n                            ],\n                            \"ResolutionsAvailable\": [\n                                {\n                                    \"Height\": 1080,\n                                    \"Width\": 1920\n                                },\n                                {\n                                    \"Height\": 720,\n                                    \"Width\": 1280\n                                },\n                                {\n                                    \"Height\": 360,\n                                    \"Width\": 640\n                                }\n                            ]\n                        },\n                        \"QualityRange\": {\n                            \"Max\": 5,\n                            \"Min\": 1\n                        }\n                    }\n                }\n            }\n        ]\n    }\n}"
 						}
 					]
-				},
-				{
-					"name": "SetVideoEncoderConfiguration",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"VideoEncoderConfiguration\": {\n        \"ForcePersistence\": false,\n        \"Configuration\": {\n            \"token\": \"{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN}}\",\n            \"Encoding\": \"H264\",\n            \"Quality\": 3.000000,\n            \"Resolution\": {\n                \"Width\": 1920,\n                \"Height\": 1080\n            },\n            \"Multicast\": {\n                \"Address\": {\n                    \"Type\": \"IPv4\",\n                    \"IPv4Address\": \"0.0.0.0\"\n                },\n                \"Port\": 8860,\n                \"TTL\": 1,\n                \"AutoStart\": false\n            }\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration",
-							"protocol": "http",
-							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
-							],
-							"port": "59882",
-							"path": [
-								"api",
-								"v3",
-								"device",
-								"name",
-								"{{EDGEX_DEVICE_NAME}}",
-								"VideoEncoderConfiguration"
-							]
-						},
-						"description": "This operation modifies a video encoder configuration. The ForcePersistence flag indicates if the changes shall remain after reboot of the device. Changes in the Multicast settings shall always be persistent. Running streams using this configuration may be immediately updated according to the new settings. The changes are not guaranteed to take effect unless the client requests a new stream URI and restarts any affected stream. NVC methods for changing a running stream are out of scope for this specification.\n\nSessionTimeout is provided as a hint for keeping rtsp session by a device. If necessary the device may adapt parameter values for SessionTimeout elements without returning an error. For the time between keep alive calls the client shall adhere to the timeout value signaled via RTSP."
-					},
-					"response": [
-						{
-							"name": "SetVideoEncoderConfiguration",
-							"originalRequest": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"VideoEncoderConfiguration\": {\n        \"ForcePersistence\": false,\n        \"Configuration\":{\n            \"token\": \"{{EDGEX_MEDIA_VIDEO_ENCODER_TOKEN}}\",\n            \"Encoding\": \"H264\",\n            \"Quality\": 3.000000,\n            \"Resolution\": {\n                \"Width\": 1920,\n                \"Height\": 1080\n            },\n            \"Multicast\": {\n                \"Address\": {\n                    \"Type\": \"IPv4\",\n                    \"IPv4Address\": \"0.0.0.0\"\n                },\n                \"Port\": 8860,\n                \"TTL\": 1,\n                \"AutoStart\": false\n            }\n        }\n        \n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/VideoEncoderConfiguration",
-									"protocol": "http",
-									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
-									],
-									"port": "59882",
-									"path": [
-										"api",
-										"v3",
-										"device",
-										"name",
-										"{{EDGEX_DEVICE_NAME}}",
-										"VideoEncoderConfiguration"
-									]
-								}
-							},
-							"status": "Internal Server Error",
-							"code": 500,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "X-Correlation-Id",
-									"value": "8888c1a3-e632-4223-9013-41c5e938eb4d"
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 05 Aug 2022 00:26:56 GMT"
-								},
-								{
-									"key": "Content-Length",
-									"value": "489"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"apiVersion\": \"v3\",\n    \"message\": \"request failed, status code: 500, err: {\\\"apiVersion\\\":\\\"v3\\\",\\\"message\\\":\\\"error writing DeviceResourece VideoEncoderConfiguration for TP-Link-C200-3fa1fe68-b915-4053-a3e1-1027f5ea88f4 -\\\\u003e failed to execute write command, \\\\u003cnil\\\\u003e -\\\\u003e invalid request for the function 'SetVideoEncoderConfiguration' of web service 'Media'. Onvif error: fault reason: , fault detail: , fault code: SOAP-ENV:Sender  \\\",\\\"statusCode\\\":500}\",\n    \"statusCode\": 500\n}"
-						}
-					]
 				}
 			]
 		},
@@ -4352,15 +3798,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4369,8 +3810,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZNodes"
 									]
-								},
-								"description": "Get the descriptions of the available PTZ Nodes.\n\nA PTZ-capable device may have multiple PTZ Nodes. The PTZ Nodes may represent mechanical PTZ drivers, uploaded PTZ drivers or digital PTZ drivers. PTZ Nodes are the lowest level entities in the PTZ control API and reflect the supported PTZ capabilities. The PTZ Node is referenced either by its name or by its reference token."
+								}
 							},
 							"response": [
 								{
@@ -4379,15 +3819,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNodes",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4430,15 +3865,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4454,8 +3884,7 @@
 											"description": "{\"NodeToken\": \"Node0\"}"
 										}
 									]
-								},
-								"description": "Get a specific PTZ Node identified by a reference token or a name."
+								}
 							},
 							"response": [
 								{
@@ -4464,15 +3893,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZNode?jsonObject={{NODE_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4538,15 +3962,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4555,8 +3974,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZConfigurations"
 									]
-								},
-								"description": "Get all the existing PTZConfigurations from the device.  \nThe default Position/Translation/Velocity Spaces are introduced to allow NVCs sending move requests without the need to specify a certain coordinate system. The default Speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.  \nThe allowed pan and tilt range for Pan/Tilt Limits is defined by a two-dimensional space range that is mapped to a specific Absolute Pan/Tilt Position Space. At least one Pan/Tilt Position Space is required by the PTZNode to support Pan/Tilt limits. The limits apply to all supported absolute, relative and continuous Pan/Tilt movements. The limits shall be checked within the coordinate system for which the limits have been specified. That means that even if movements are specified in a different coordinate system, the requested movements shall be transformed to the coordinate system of the limits where the limits can be checked. When a relative or continuous movements is specified, which would leave the specified limits, the PTZ unit has to move along the specified limits. The Zoom Limits have to be interpreted accordingly."
+								}
 							},
 							"response": [
 								{
@@ -4565,15 +3983,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurations",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4611,7 +4024,7 @@
 							]
 						},
 						{
-							"name": "Get PTZConfiguration",
+							"name": "PTZConfiguration",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true
 							},
@@ -4628,15 +4041,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4652,8 +4060,7 @@
 											"description": "{\"PTZConfigurationToken\": \"PTZConfiguration0\"}"
 										}
 									]
-								},
-								"description": "Get a specific PTZconfiguration from the device, identified by its reference token or name.\n\nThe default Position/Translation/Velocity Spaces are introduced to allow NVCs sending move requests without the need to specify a certain coordinate system. The default Speeds are introduced to control the speed of move requests (absolute, relative, preset), where no explicit speed has been set.\n\nThe allowed pan and tilt range for Pan/Tilt Limits is defined by a two-dimensional space range that is mapped to a specific Absolute Pan/Tilt Position Space. At least one Pan/Tilt Position Space is required by the PTZNode to support Pan/Tilt limits. The limits apply to all supported absolute, relative and continuous Pan/Tilt movements. The limits shall be checked within the coordinate system for which the limits have been specified. That means that even if movements are specified in a different coordinate system, the requested movements shall be transformed to the coordinate system of the limits where the limits can be checked. When a relative or continuous movements is specified, which would leave the specified limits, the PTZ unit has to move along the specified limits. The Zoom Limits have to be interpreted accordingly."
+								}
 							},
 							"response": [
 								{
@@ -4662,15 +4069,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration?jsonObject={{PTZ_CONFIGURATION_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4731,15 +4133,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4755,9 +4152,7 @@
 											"description": "{\"ConfigurationToken\": \"PTZConfiguration0\"}"
 										}
 									]
-								},
-								"description": "List supported coordinate systems including their range limitations. Therefore, the options MAY differ depending on whether the PTZ Configuration is assigned to a Profile containing a Video Source Configuration. In that case, the options may additionally contain coordinate systems referring to the image coordinate system described by the Video Source Configuration. If the PTZ Node supports continuous movements, it shall return a Timeout Range within which Timeouts are accepted by the PTZ Node."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZConfigurationOptions",
@@ -4765,15 +4160,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfigurationOptions?jsonObject={{GET_CONFIGURATION_OPTIONS_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4818,7 +4208,7 @@
 							]
 						},
 						{
-							"name": "SetPTZConfiguration",
+							"name": "PTZConfiguration",
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -4832,15 +4222,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4849,9 +4234,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZConfiguration"
 									]
-								},
-								"description": "Set/update a existing PTZConfiguration on the device."
-							},
+								}							},
 							"response": [
 								{
 									"name": "SetConfiguration",
@@ -4868,15 +4251,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZConfiguration",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -4928,15 +4306,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddPTZConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddPTZConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -4945,9 +4318,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AddPTZConfiguration"
 									]
-								},
-								"description": "Add a new PTZConfiguration on the device."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AddPTZConfiguration",
@@ -4964,15 +4335,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddPTZConfiguration",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AddPTZConfiguration",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5024,15 +4390,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemovePTZConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemovePTZConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5041,9 +4402,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"RemovePTZConfiguration"
 									]
-								},
-								"description": "Remove a PTZConfiguration on the device."
-							},
+								}							},
 							"response": [
 								{
 									"name": "RemovePTZConfiguration",
@@ -5060,15 +4419,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemovePTZConfiguration",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/RemovePTZConfiguration",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5125,15 +4479,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5142,9 +4491,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZAbsoluteMove"
 									]
-								},
-								"description": "Operation to move pan,tilt or zoom to a absolute destination.\n\nThe speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZAbsoluteMove",
@@ -5161,15 +4508,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZAbsoluteMove",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5221,15 +4563,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5238,9 +4575,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZRelativeMove"
 									]
-								},
-								"description": "Operation for Relative Pan/Tilt and Zoom Move. The operation is supported if the PTZNode supports at least one relative Pan/Tilt or Zoom space.\n\nThe speed argument is optional. If an x/y speed value is given it is up to the device to either use the x value as absolute resoluting speed vector or to map x and y to the component speed. If the speed argument is omitted, the default speed set by the PTZConfiguration will be used."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZRelativeMove",
@@ -5257,15 +4592,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRelativeMove",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5317,15 +4647,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5334,9 +4659,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZContinuousMove"
 									]
-								},
-								"description": "Operation for continuous Pan/Tilt and Zoom movements. The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space. If the space argument is omitted, the default space set by the PTZConfiguration will be used."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZContinuousMove",
@@ -5353,15 +4676,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZContinuousMove",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5416,15 +4734,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5440,9 +4753,7 @@
 											"description": "{\"ProfileToken\":\"profile_1\"}"
 										}
 									]
-								},
-								"description": "Operation to request PTZ status for the Node in the selected profile."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZStatus",
@@ -5450,15 +4761,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStatus?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5516,15 +4822,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5533,9 +4834,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZStop"
 									]
-								},
-								"description": "Operation to stop ongoing pan, tilt and zoom movements of absolute relative and continuous type. If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZStop",
@@ -5552,15 +4851,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZStop",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5603,7 +4897,7 @@
 					"name": "PTZPreset",
 					"item": [
 						{
-							"name": "Set PTZPreset",
+							"name": "PTZPreset",
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -5617,15 +4911,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPreset",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPreset",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5634,9 +4923,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZPreset"
 									]
-								},
-								"description": "The SetPreset command saves the current device position parameters so that the device can move to the saved preset position through the GotoPreset operation. In order to create a new preset, the SetPresetRequest contains no PresetToken. If creation is successful, the Response contains the PresetToken which uniquely identifies the Preset. An existing Preset can be overwritten by specifying the PresetToken of the corresponding Preset. In both cases (overwriting or creation) an optional PresetName can be specified. The operation fails if the PTZ device is moving during the SetPreset operation. The device MAY internally save additional states such as imaging properties in the PTZ Preset which then should be recalled in the GotoPreset operation."
-							},
+								}							},
 							"response": [
 								{
 									"name": "SetPreset",
@@ -5653,15 +4940,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SetPreset",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SetPreset",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5704,15 +4986,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5727,9 +5004,7 @@
 											"value": "{{PTZ_MEDIA_PROFILE_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "Operation to request all PTZ presets for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZPresets",
@@ -5737,15 +5012,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZPresets?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5803,15 +5073,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoPreset",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoPreset",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5820,9 +5085,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZGotoPreset"
 									]
-								},
-								"description": "Operation to go to a saved preset position for the PTZNode in the selected profile. The operation is supported if there is support for at least on PTZ preset by the PTZNode."
-							},
+								}							},
 							"response": []
 						},
 						{
@@ -5840,15 +5103,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRemovePreset",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZRemovePreset",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5857,9 +5115,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZRemovePreset"
 									]
-								},
-								"description": "Operation to remove a PTZ preset for the Node in the selected profile. The operation is supported if the PresetPosition capability exists for teh Node in the selected profile."
-							},
+								}							},
 							"response": []
 						}
 					]
@@ -5882,15 +5138,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5918,15 +5169,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZGotoHomePosition",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -5978,15 +5224,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -5995,9 +5236,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"PTZHomePosition"
 									]
-								},
-								"description": "Operation to save current position as the home position. The PTZHomePosition command returns with a failure if the “home” position is fixed and cannot be overwritten. If the PTZHomePosition is successful, it is possible to recall the Home Position with the PTZGotoHomePosition command."
-							},
+								}							},
 							"response": [
 								{
 									"name": "PTZHomePosition",
@@ -6014,15 +5253,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZHomePosition",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6079,15 +5313,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6115,15 +5344,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PTZSendAuxiliaryCommand",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6173,15 +5397,10 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventProperties",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventProperties",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -6190,9 +5409,7 @@
 								"{{EDGEX_DEVICE_NAME}}",
 								"EventProperties"
 							]
-						},
-						"description": "The WS-BaseNotification specification defines a set of OPTIONAL WS-ResouceProperties. This specification does not require the implementation of the WS-ResourceProperty interface. Instead, the subsequent direct interface shall be implemented by an ONVIF compliant device in order to provide information about the FilterDialects, Schema files and topics supported by the device."
-					},
+						}					},
 					"response": [
 						{
 							"name": "EventProperties",
@@ -6200,15 +5417,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventProperties",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/EventProperties",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6260,15 +5472,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/BaseNotificationSubscription",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/BaseNotificationSubscription",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -6296,15 +5503,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/BaseNotificationSubscription",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/BaseNotificationSubscription",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6356,15 +5558,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PullPointSubscription",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PullPointSubscription",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -6392,15 +5589,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PullPointSubscription",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/PullPointSubscription",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6452,15 +5644,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/UnsubscribeCameraEvent",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/UnsubscribeCameraEvent",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -6488,15 +5675,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/UnsubscribeCameraEvent",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/UnsubscribeCameraEvent",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6542,20 +5724,15 @@
 					"name": "Profile Configuration",
 					"item": [
 						{
-							"name": "Get Media2Profiles",
+							"name": "Media2Profiles",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2Profiles",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2Profiles",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6564,9 +5741,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2Profiles"
 									]
-								},
-								"description": "Any endpoint can ask for the existing media profiles of a device using the GetProfiles command. Pre-configured or dynamically configured profiles can be retrieved using this command. This command lists all configured profiles in a device. The client does not need to know the media profile in order to use the command."
-							},
+								}							},
 							"response": [
 								{
 									"name": "GetMedia2Profiles",
@@ -6574,15 +5749,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2Profiles",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2Profiles",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6625,15 +5795,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6642,9 +5807,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2AnalyticsConfigurations"
 									]
-								},
-								"description": "By default this operation lists all existing video analytics configurations for a device. Provide a profile token to list only configurations that are compatible with the profile. If a configuration token is provided only a single configuration will be returned."
-							},
+								}							},
 							"response": [
 								{
 									"name": "Media2AnalyticsConfigurations",
@@ -6652,15 +5815,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AnalyticsConfigurations",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6712,15 +5870,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AddConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2AddConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6729,9 +5882,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2AddConfiguration"
 									]
-								},
-								"description": "This operation adds one or more PTZConfigurations to an existing media profile. If a configuration exists in the media profile, it will be replaced. A device shall support adding a compatible Configuration to a Profile containing a VideoSourceConfiguration and shall support streaming video data of such a profile.\n\nNote that OSD elements must be added via the CreateOSD command."
-							},
+								}							},
 							"response": []
 						},
 						{
@@ -6749,15 +5900,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2RemoveConfiguration",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/Media2RemoveConfiguration",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6766,9 +5912,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"Media2RemoveConfiguration"
 									]
-								},
-								"description": "This operation removes the listed configurations from an existing media profile. If the media profile does not contain one of the listed configurations that item shall be ignored."
-							},
+								}							},
 							"response": []
 						}
 					]
@@ -6782,15 +5926,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedAnalyticsModules",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedAnalyticsModules",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6799,9 +5938,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"SupportedAnalyticsModules"
 									]
-								},
-								"description": "List all analytics modules that are supported by the given VideoAnalyticsConfiguration."
-							},
+								}							},
 							"response": [
 								{
 									"name": "SupportedAnalyticsModules",
@@ -6809,15 +5946,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedAnalyticsModules",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SupportedAnalyticsModules",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6855,20 +5987,15 @@
 							]
 						},
 						{
-							"name": "GetAnalyticsModules",
+							"name": "AnalyticsModules",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6883,9 +6010,7 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "List the currently assigned set of analytics modules of a VideoAnalyticsConfiguration."
-							},
+								}							},
 							"response": [
 								{
 									"name": "GetAnalyticsModules",
@@ -6893,15 +6018,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -6945,6 +6065,36 @@
 							]
 						},
 						{
+							"name": "AnalyticsModules",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"AnalyticsModules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"AnalyticsModule\": [\n            {\n                \"Name\": \"Viproc\",\n                \"Type\": \"{{ANALYTIC_MODULE_TYPE}}\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"{{ANALYTIC_MODULE_OPTION_NAME}}\",\n                            \"Value\": \"{{ANALYTIC_MODULE_OPTION_VALUE}}\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules",
+									"host": [
+										"{{CORE_COMMAND_URL}}"
+									],
+									"path": [
+										"api",
+										"v3",
+										"device",
+										"name",
+										"{{EDGEX_DEVICE_NAME}}",
+										"AnalyticsModules"
+									]
+								}							},
+							"response": []
+						},
+						{
 							"name": "CreateAnalyticsModules",
 							"request": {
 								"method": "PUT",
@@ -6959,15 +6109,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateAnalyticsModules",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateAnalyticsModules",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -6976,9 +6121,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"CreateAnalyticsModules"
 									]
-								},
-								"description": "Add one or more analytics modules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via SupportedAnalyticsModules, where the Name of the supported AnalyticsModules correspond to the type of an AnalyticsModule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the analytics module must match those of the corresponding AnalyticsModuleDescription.\n\nAlthough this method is mandatory a device implementation may not support adding modules. Instead it can provide a fixed set of predefined configurations via the media service functions GetCompatibleVideoAnalyticsConfigurations and Media2AnalyticsConfigurations.\n\nThe device shall ensure that a corresponding analytics engine starts operation when a client subscribes directly or indirectly for events produced by the analytics or rule engine or when a client requests the corresponding scene description stream. An analytics module must be attached to a Video source using the media profiles before it can be used. In case differing analytics configurations are attached to the same profile it is undefined which of the analytics module configuration becomes active if no stream is activated or multiple streams with different profiles are activated at the same time."
-							},
+								}							},
 							"response": [
 								{
 									"name": "CreateAnalyticsModules",
@@ -6995,15 +6138,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateAnalyticsModules",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CreateAnalyticsModules",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7055,15 +6193,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteAnalyticsModules",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteAnalyticsModules",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7072,9 +6205,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"DeleteAnalyticsModules"
 									]
-								},
-								"description": "Remove one or more analytics modules from a VideoAnalyticsConfiguration referenced by their names."
-							},
+								}							},
 							"response": [
 								{
 									"name": "DeleteAnalyticsModules",
@@ -7091,15 +6222,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteAnalyticsModules",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteAnalyticsModules",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7142,15 +6268,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7165,9 +6286,7 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "Return the options for the supported analytics modules that specify an Option attribute."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AnalyticsModuleOptions",
@@ -7175,15 +6294,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7225,43 +6339,6 @@
 									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200,\n    \"event\": {\n        \"apiVersion\": \"v3\",\n        \"id\": \"460b6e4f-88d7-476d-ab9c-d46c5f656124\",\n        \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n        \"profileName\": \"onvif-camera\",\n        \"sourceName\": \"AnalyticsModuleOptions\",\n        \"origin\": 1665460132225687940,\n        \"readings\": [\n            {\n                \"id\": \"42a9e19c-82f6-4552-9f1d-459bfc55600a\",\n                \"origin\": 1665460132225687940,\n                \"deviceName\": \"Intel-SimCamera-001caffe-48ca-450d-bbd4-cb4f8630ef19\",\n                \"resourceName\": \"AnalyticsModuleOptions\",\n                \"profileName\": \"onvif-camera\",\n                \"valueType\": \"Object\",\n                \"value\": \"\",\n                \"objectValue\": {\n                    \"Options\": [\n                        {\n                            \"IntRange\": {\n                                \"Max\": 100,\n                                \"Min\": 0\n                            },\n                            \"Name\": \"Sensitivity\",\n                            \"Type\": \"tt:IntRange\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}"
 								}
 							]
-						},
-						{
-							"name": "ModifyAnalyticsModules",
-							"request": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"AnalyticsModules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"AnalyticsModule\": [\n            {\n                \"Name\": \"Viproc\",\n                \"Type\": \"{{ANALYTIC_MODULE_TYPE}}\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"{{ANALYTIC_MODULE_OPTION_NAME}}\",\n                            \"Value\": \"{{ANALYTIC_MODULE_OPTION_VALUE}}\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsModules",
-									"protocol": "http",
-									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
-									],
-									"port": "59882",
-									"path": [
-										"api",
-										"v3",
-										"device",
-										"name",
-										"{{EDGEX_DEVICE_NAME}}",
-										"AnalyticsModules"
-									]
-								},
-								"description": "Modify the settings of one or more analytics modules of a VideoAnalyticsConfiguration. The modules are referenced by their names. It is allowed to pass only a subset to be modified."
-							},
-							"response": []
 						}
 					]
 				},
@@ -7274,15 +6351,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7297,9 +6369,7 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "List all rules that are supported by the given VideoAnalyticsConfiguration."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AnalyticsSupportedRules",
@@ -7307,15 +6377,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsSupportedRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7359,20 +6424,15 @@
 							]
 						},
 						{
-							"name": "Get AnalyticsRules",
+							"name": "AnalyticsRules",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7387,9 +6447,7 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "List the currently assigned set of rules of a VideoAnalyticsConfiguration."
-							},
+								}							},
 							"response": [
 								{
 									"name": "GetRules",
@@ -7397,15 +6455,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7449,20 +6502,99 @@
 							]
 						},
 						{
+							"name": "AnalyticsRules",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"ClassFilter\",\n                            \"Value\": \" Bike Car Truck\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
+									"host": [
+										"{{CORE_COMMAND_URL}}"
+									],
+									"path": [
+										"api",
+										"v3",
+										"device",
+										"name",
+										"{{EDGEX_DEVICE_NAME}}",
+										"AnalyticsRules"
+									]
+								}							},
+							"response": [
+								{
+									"name": "ModifyRules",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"ClassFilter\", \n                            \"Value\":\" Bike Car Truck\"\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
+											"host": [
+												"{{CORE_COMMAND_URL}}"
+											],
+											"path": [
+												"api",
+												"v3",
+												"device",
+												"name",
+												"{{EDGEX_DEVICE_NAME}}",
+												"AnalyticsRules"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "X-Correlation-Id",
+											"value": "ea1d0040-3a30-4fbb-a0ac-50a1b90f3e36"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 11 Oct 2022 03:50:16 GMT"
+										},
+										{
+											"key": "Content-Length",
+											"value": "37"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200\n}"
+								}
+							]
+						},
+						{
 							"name": "AnalyticsRuleOptions",
 							"request": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7477,9 +6609,7 @@
 											"value": "{{ANALYTIC_CONFIG_TOKEN_BASE64}}"
 										}
 									]
-								},
-								"description": "Return the options for the supported rules that specify an Option attribute."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AnalyticsRuleOptions",
@@ -7487,15 +6617,10 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRuleOptions?jsonObject={{ANALYTIC_CONFIG_TOKEN_BASE64}}",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7553,15 +6678,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7570,9 +6690,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsCreateRules"
 									]
-								},
-								"description": "Add one or more rules to an existing VideoAnalyticsConfiguration. The available supported types can be retrieved via AnalyticsSupportedRules, where the Name of the supported rule correspond to the type of an rule instance.\n\nPass unique module names which can be later used as reference. The Parameters of the rules must match those of the corresponding description.\n\nAlthough this method is mandatory a device implementation must not support adding rules. Instead it can provide a fixed set of predefined configurations via the media service function GetCompatibleVideoAnalyticsConfigurations."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AnalyticsCreateRules",
@@ -7589,15 +6707,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsCreateRules",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7649,15 +6762,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7666,9 +6774,7 @@
 										"{{EDGEX_DEVICE_NAME}}",
 										"AnalyticsDeleteRules"
 									]
-								},
-								"description": "Remove one or more rules from a VideoAnalyticsConfiguration."
-							},
+								}							},
 							"response": [
 								{
 									"name": "AnalyticsDeleteRules",
@@ -7685,15 +6791,10 @@
 											}
 										},
 										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
-											"protocol": "http",
+											"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsDeleteRules",
 											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
+												"{{CORE_COMMAND_URL}}"
 											],
-											"port": "59882",
 											"path": [
 												"api",
 												"v3",
@@ -7729,102 +6830,6 @@
 									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200\n}"
 								}
 							]
-						},
-						{
-							"name": "Modify AnalyticsRules",
-							"request": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\": \"ClassFilter\",\n                            \"Value\": \" Bike Car Truck\"\n                        }\n                    ]\n                }\n            }\n        ]\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
-									"protocol": "http",
-									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
-									],
-									"port": "59882",
-									"path": [
-										"api",
-										"v3",
-										"device",
-										"name",
-										"{{EDGEX_DEVICE_NAME}}",
-										"AnalyticsRules"
-									]
-								},
-								"description": "Modify one or more rules of a VideoAnalyticsConfiguration. The rules are referenced by their names."
-							},
-							"response": [
-								{
-									"name": "ModifyRules",
-									"originalRequest": {
-										"method": "PUT",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"AnalyticsRules\": {\n        \"ConfigurationToken\": \"{{ANALYTIC_CONFIG_TOKEN}}\",\n        \"Rule\": [\n            {\n                \"Name\": \"MyMotionDetectorRule\",\n                \"Type\": \"tt:ObjectInField\",\n                \"Parameters\": {\n                    \"SimpleItem\": [\n                        {\n                            \"Name\":\"ClassFilter\", \n                            \"Value\":\" Bike Car Truck\"\n                        }\n                    ]\n                }\n                    \n            }\n        ]\n    }\n}",
-											"options": {
-												"raw": {
-													"language": "json"
-												}
-											}
-										},
-										"url": {
-											"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/AnalyticsRules",
-											"protocol": "http",
-											"host": [
-												"0",
-												"0",
-												"0",
-												"0"
-											],
-											"port": "59882",
-											"path": [
-												"api",
-												"v3",
-												"device",
-												"name",
-												"{{EDGEX_DEVICE_NAME}}",
-												"AnalyticsRules"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Content-Type",
-											"value": "application/json"
-										},
-										{
-											"key": "X-Correlation-Id",
-											"value": "ea1d0040-3a30-4fbb-a0ac-50a1b90f3e36"
-										},
-										{
-											"key": "Date",
-											"value": "Tue, 11 Oct 2022 03:50:16 GMT"
-										},
-										{
-											"key": "Content-Length",
-											"value": "37"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"apiVersion\": \"v3\",\n    \"statusCode\": 200\n}"
-								}
-							]
 						}
 					]
 				}
@@ -7834,20 +6839,15 @@
 			"name": "Custom",
 			"item": [
 				{
-					"name": "Get MACAddress",
+					"name": "MACAddress",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -7861,20 +6861,15 @@
 					},
 					"response": [
 						{
-							"name": "Get MACAddress",
+							"name": "MACAddress",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -7912,7 +6907,7 @@
 					]
 				},
 				{
-					"name": "Set MACAddress",
+					"name": "MACAddress",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -7926,15 +6921,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -7948,7 +6938,7 @@
 					},
 					"response": [
 						{
-							"name": "Set MACAddress",
+							"name": "MACAddress",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
@@ -7962,15 +6952,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/MACAddress",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8008,20 +6993,15 @@
 					]
 				},
 				{
-					"name": "Get FriendlyName",
+					"name": "FriendlyName",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -8035,20 +7015,15 @@
 					},
 					"response": [
 						{
-							"name": "Get FriendlyName",
+							"name": "FriendlyName",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8086,7 +7061,7 @@
 					]
 				},
 				{
-					"name": "Set FriendlyName",
+					"name": "FriendlyName",
 					"request": {
 						"method": "PUT",
 						"header": [],
@@ -8100,15 +7075,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -8122,7 +7092,7 @@
 					},
 					"response": [
 						{
-							"name": "Set FriendlyName",
+							"name": "FriendlyName",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
@@ -8136,15 +7106,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/FriendlyName",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8182,7 +7147,7 @@
 					]
 				},
 				{
-					"name": "Get CustomMetadata",
+					"name": "CustomMetadata",
 					"event": [
 						{
 							"listen": "test",
@@ -8212,15 +7177,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -8234,20 +7194,15 @@
 					},
 					"response": [
 						{
-							"name": "Get CustomMetadata",
+							"name": "CustomMetadata",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8288,15 +7243,10 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata?jsonObject={{ptz_enc}}",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata?jsonObject={{ptz_enc}}",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8341,7 +7291,7 @@
 					]
 				},
 				{
-					"name": "Set CustomMetadata",
+					"name": "CustomMetadata",
 					"event": [
 						{
 							"listen": "test",
@@ -8368,15 +7318,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -8390,7 +7335,7 @@
 					},
 					"response": [
 						{
-							"name": "Set CustomMetadata",
+							"name": "CustomMetadata",
 							"originalRequest": {
 								"method": "PUT",
 								"header": [],
@@ -8404,15 +7349,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/CustomMetadata",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",
@@ -8450,7 +7390,7 @@
 					]
 				},
 				{
-					"name": "Delete CustomMetadata",
+					"name": "DeleteCustomMetadata",
 					"event": [
 						{
 							"listen": "test",
@@ -8477,15 +7417,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteCustomMetadata",
-							"protocol": "http",
+							"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteCustomMetadata",
 							"host": [
-								"0",
-								"0",
-								"0",
-								"0"
+								"{{CORE_COMMAND_URL}}"
 							],
-							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -8513,15 +7448,10 @@
 									}
 								},
 								"url": {
-									"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteCustomMetadata",
-									"protocol": "http",
+									"raw": "{{CORE_COMMAND_URL}}/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/DeleteCustomMetadata",
 									"host": [
-										"0",
-										"0",
-										"0",
-										"0"
+										"{{CORE_COMMAND_URL}}"
 									],
-									"port": "59882",
 									"path": [
 										"api",
 										"v3",

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -3884,7 +3884,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://0.0.0.0:59989/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
+							"raw": "http://0.0.0.0:59882/api/v3/device/name/{{EDGEX_DEVICE_NAME}}/SnapshotUri?jsonObject={{EDGEX_MEDIA_PROFILE_BASE64}}",
 							"protocol": "http",
 							"host": [
 								"0",
@@ -3892,7 +3892,7 @@
 								"0",
 								"0"
 							],
-							"port": "59989",
+							"port": "59882",
 							"path": [
 								"api",
 								"v3",
@@ -3907,8 +3907,7 @@
 									"value": "{{EDGEX_MEDIA_PROFILE_BASE64}}"
 								}
 							]
-						},
-						"description": "This request returns a snapshot of the video stream at the time the command is given.\n\nIt is returned in a binary format."
+						}
 					},
 					"response": [
 						{

--- a/doc/postman/device-onvif-camera.postman_collection.json
+++ b/doc/postman/device-onvif-camera.postman_collection.json
@@ -3908,7 +3908,7 @@
 								}
 							]
 						},
-						"description": ""
+						"description": "This request returns a snapshot of the video stream at the time the command is given.\n\nIt is returned in a binary format."
 					},
 					"response": [
 						{
@@ -4519,7 +4519,7 @@
 					]
 				},
 				{
-					"name": "PTZConfiguration",
+					"name": "Configuration",
 					"item": [
 						{
 							"name": "PTZConfigurations",
@@ -4612,7 +4612,7 @@
 							]
 						},
 						{
-							"name": "GetConfiguration",
+							"name": "Get PTZConfiguration",
 							"protocolProfileBehavior": {
 								"disableBodyPruning": true
 							},
@@ -4819,7 +4819,7 @@
 							]
 						},
 						{
-							"name": "SetConfiguration",
+							"name": "SetPTZConfiguration",
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -5604,7 +5604,7 @@
 					"name": "PTZPreset",
 					"item": [
 						{
-							"name": "SetPreset",
+							"name": "Set PTZPreset",
 							"request": {
 								"method": "PUT",
 								"header": [],
@@ -6543,7 +6543,7 @@
 					"name": "Profile Configuration",
 					"item": [
 						{
-							"name": "GetProfiles",
+							"name": "Get Media2Profiles",
 							"request": {
 								"method": "GET",
 								"header": [],
@@ -7360,7 +7360,7 @@
 							]
 						},
 						{
-							"name": "GetRules",
+							"name": "Get AnalyticsRules",
 							"request": {
 								"method": "GET",
 								"header": [],
@@ -7732,7 +7732,7 @@
 							]
 						},
 						{
-							"name": "ModifyRules",
+							"name": "Modify AnalyticsRules",
 							"request": {
 								"method": "PUT",
 								"header": [],

--- a/doc/postman/device-onvif-camera.postman_environment.json
+++ b/doc/postman/device-onvif-camera.postman_environment.json
@@ -127,6 +127,12 @@
 			"value": "40",
 			"type": "default",
 			"enabled": true
+		},
+		{
+			"key": "CORE_COMMAND_URL",
+			"value": "http://0.0.0.0:59882",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",


### PR DESCRIPTION
BREAKING CHANGE: Changed the name of many device commands to include a prefix of the onvif service they belong to. For example Status becomes PTZStatus, Profiles becomes MediaProfiles, etc.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **n/a**
- [ ] **TODO** I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] **TODO** I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Make sure to **clean edgex**

- Build and run latest edgex main and this branch of device-onvif-camera
- Import the device-onvif-camera postman collection
- Import the postman env file if not done already
- Update postman env with your camera's values
- Run the postman collection
- Verify commands work as they did before

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->