### PR TITLE
feat: replace gorilla/mux with labstack/echo

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -17,9 +17,6 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 google/uuid 1.1.0 (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
-gorilla/mux 1.6.2 (BSD-3) https://github.com/gorilla/mux
-https://github.com/gorilla/mux/blob/master/LICENSE
-
 hashicorp/consul 1.4.0 (MPL-2.0) https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.27
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.1.0-dev.8
 	github.com/google/uuid v1.3.1
-	github.com/gorilla/mux v1.8.0
+	github.com/labstack/echo/v4 v4.11.1
 	github.com/stretchr/testify v1.8.4
 )
 
@@ -50,7 +50,6 @@ require (
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
-	github.com/labstack/echo/v4 v4.11.1 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/consul/api v1.24.0 h1:u2XyStA2j0jnCiVUU7Qyrt8idjRn4ORhK6DlvZ3bWhA=


### PR DESCRIPTION
closes: #378 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run make docker to build the image
From the latest compose-builder run `make run no-secty device-dev ds-onvif-camera`
Set the log level of device-onvif-camera to `DEBUG`
Verify the device-onvif-camera service bootstraps successfully and contains the following log message:
```
level=INFO ts=2023-08-28T04:27:18.179454Z app=device-onvif-camera source=basenotificationresthandler.go:53 msg="Route /api/v3/onvifevent/:deviceName/:resourceName added."
```
Send an ONVIF notification by executing the following command:
```
curl -X POST localhost:59984/api/v3/onvifevent/test/test
```
Verify the log contains the following message:
```
level=DEBUG ts=2023-08-28T04:27:21.803792Z app=device-onvif-camera source=basenotificationresthandler.go:62 msg="Received POST for Device=test Resource=test"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->