### PR TITLE
fix: Ensures that the parsed value is within the bounds of int32

### DIFF
--- a/internal/driver/subscriptionrequest.go
+++ b/internal/driver/subscriptionrequest.go
@@ -93,10 +93,11 @@ func newSubscriptionRequest(attributes map[string]interface{}, requestData []byt
 
 	messageLimit, ok := attributes[DefaultMessageLimit]
 	if request.MessageLimit == nil && ok {
-		val, err := strconv.Atoi(fmt.Sprint(messageLimit))
+		val64, err := strconv.ParseInt(fmt.Sprint(messageLimit), 10, 32)
 		if err != nil {
 			return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to parse the request attribute '%s'", DefaultMessageLimit), err)
 		}
+		val := int(val64)
 		request.MessageLimit = &val
 	}
 	return request, nil


### PR DESCRIPTION
Fixes [https://github.com/edgexfoundry/device-onvif-camera/security/code-scanning/2](https://github.com/edgexfoundry/device-onvif-camera/security/code-scanning/2)

To fix the problem, we need to ensure that the integer value parsed from the string is within the bounds of `int32` before converting it. This can be done by using `strconv.ParseInt` with a bit size of 32, which directly parses the string into an `int32` value, or by adding explicit bounds checks before the conversion.

In this case, we will use `strconv.ParseInt` with a bit size of 32 to parse the `MessageLimit` value. This ensures that the parsed value is within the bounds of `int32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
